### PR TITLE
Refactor CommonProps

### DIFF
--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -23,6 +23,8 @@ exports.reactUnmount = function(el) {
   }
 }
 
+exports.cloneElement_ = React.cloneElement
+
 exports.createElement_ = function(component, props, children) {
   // The type of `children` is `Array ReactElement`. If we pass that in as
   // third parameter of `React.createElement` directly, React complains about

--- a/src/Elmish/React.purs
+++ b/src/Elmish/React.purs
@@ -4,6 +4,7 @@ module Elmish.React
     , ReactComponentInstance
     , class ValidReactProps, class ValidReactPropsRL
     , class ReactChildren, asReactChildren
+    , cloneElement
     , createElement
     , createElement'
     , getState
@@ -14,14 +15,14 @@ module Elmish.React
 
 import Prelude
 
-import Data.Function.Uncurried (Fn2, Fn3, runFn3)
+import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
 import Data.Nullable (Nullable)
 import Effect (Effect)
+import Elmish.Foreign (class CanPassToJavaScript)
 import Prim.RowList (class RowToList, kind RowList, Cons, Nil)
 import Prim.TypeError (Text, class Fail)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM (Element)
-import Elmish.Foreign (class CanPassToJavaScript)
 
 -- | Instantiated subtree of React DOM. JSX syntax produces values of this type.
 foreign import data ReactElement :: Type
@@ -35,8 +36,6 @@ foreign import data ReactComponent :: Type -> Type
 -- | A specific instance of a React component - i.e. an object that has `state`
 -- | and `props` properties on it.
 foreign import data ReactComponentInstance :: Type
-
-foreign import createElement_ :: forall props. Fn3 (ReactComponent props) props (Array ReactElement) ReactElement
 
 -- | The PureScript import of the React's `createElement` function. Takes a
 -- | component constructor, a record of props, some children, and returns a
@@ -54,10 +53,17 @@ createElement component props content = runFn3 createElement_ component props $ 
 createElement' :: forall props
      . ValidReactProps props
     => ReactComponent props
-    -> props                        -- Props
+    -> props
     -> ReactElement
 createElement' component props = createElement component props ([] :: Array ReactElement)
 
+-- | The PureScript import of the React's `cloneElement` function
+cloneElement :: forall props
+     . ValidReactProps props
+    => ReactElement
+    -> props
+    -> ReactElement
+cloneElement = runFn2 cloneElement_
 
 -- | Asserts that the given type is a valid React props structure. Currently
 -- | there are three rules for what is considered "valid":
@@ -111,6 +117,9 @@ foreign import setState :: forall state. Fn3 ReactComponentInstance state (Effec
 
 foreign import reactMount :: Fn2 Element ReactElement (Effect Unit)
 foreign import reactUnmount :: Element -> Effect Unit
+
+foreign import createElement_ :: forall props. Fn3 (ReactComponent props) props (Array ReactElement) ReactElement
+foreign import cloneElement_ :: forall props. Fn2 ReactElement props ReactElement
 
 -- This instance allows including `ReactElement` in view arguments.
 instance tojsReactElement :: CanPassToJavaScript ReactElement

--- a/src/Elmish/React/CommonProps.purs
+++ b/src/Elmish/React/CommonProps.purs
@@ -1,0 +1,41 @@
+module Elmish.React.CommonProps
+    ( CommonProps
+    , withCommonProps
+    , withKey
+    , withPropsUnsafe
+    ) where
+
+import Prelude
+
+import Elmish.React (class ValidReactProps, ReactElement, cloneElement)
+import Elmish.React.Import (class IsSubsetOf)
+
+-- | Row of props that are common to all React components, without having to
+-- | declare them.
+type CommonProps = ( key :: String )
+
+-- | Adds a `key` prop to an existing `ReactElement`
+withKey :: String -> ReactElement -> ReactElement
+withKey key = withCommonProps { key }
+
+-- | To an existing `ReactElement`, adds some props that are member of
+-- | `CommonProps`. At the momnent, `CommonProps` has exactly one member
+-- | (`key`), so this function is here mostly just as a template for defining a
+-- | similar function locally in your project for adding your own project-local
+-- | common props.
+withCommonProps :: forall props
+     . ValidReactProps {|props}
+    => IsSubsetOf props CommonProps
+    => {|props}
+    -> ReactElement
+    -> ReactElement
+withCommonProps = withPropsUnsafe
+
+-- | A direct import of `React.cloneElement` (see
+-- | https://reactjs.org/docs/react-api.html#cloneelement)
+withPropsUnsafe :: forall props
+     . ValidReactProps {|props}
+    => {|props}
+    -> ReactElement
+    -> ReactElement
+withPropsUnsafe = flip cloneElement

--- a/src/Elmish/React/CommonProps.purs
+++ b/src/Elmish/React/CommonProps.purs
@@ -18,8 +18,8 @@ type CommonProps = ( key :: String )
 withKey :: String -> ReactElement -> ReactElement
 withKey key = withCommonProps { key }
 
--- | To an existing `ReactElement`, adds some props that are member of
--- | `CommonProps`. At the momnent, `CommonProps` has exactly one member
+-- | To an existing `ReactElement`, adds some props that are members of
+-- | `CommonProps`. At the moment, `CommonProps` has exactly one member
 -- | (`key`), so this function is here mostly just as a template for defining a
 -- | similar function locally in your project for adding your own project-local
 -- | common props.

--- a/src/Elmish/React/Import.purs
+++ b/src/Elmish/React/Import.purs
@@ -1,6 +1,5 @@
 module Elmish.React.Import
-    ( CommonProps
-    , EmptyProps
+    ( EmptyProps
     , ImportedReactComponentConstructor'
     , ImportedReactComponentConstructor
     , ImportedReactComponentConstructorWithContent
@@ -12,10 +11,6 @@ import Elmish.React (class ReactChildren, class ValidReactProps, ReactComponent,
 import Type.Row (type (+))
 import Prim.Row as Row
 
--- | Row of props that are common to all React components, without having to
--- | declare them.
-type CommonProps = ( id :: String, key :: String )
-
 -- | And empty open row. To be used for components that don't have any optional
 -- | or any required props.
 type EmptyProps (r :: #Type) = ( | r )
@@ -25,8 +20,8 @@ type EmptyProps (r :: #Type) = ( | r )
 -- | (including an empty subset) to be passed in.
 type ImportedReactComponentConstructor' reqProps optProps result =
     forall props
-     . IsSubsetOf props (reqProps + optProps + CommonProps)
-    => IsSubsetOf (reqProps ()) props
+     . IsSubsetOf props (reqProps + optProps + ())
+    => IsSubsetOf (reqProps + ()) props
     => ValidReactProps { | props }
     => { | props }
     -> result


### PR DESCRIPTION
As discussed on Slack:

**Motivation:**
1. @gasi recently pointed out that `id` shouldn't be a common prop, because, while it is indeed common, having it readily available leads to bad design.
2. @sassela  reached out to me just now, asking about adding `data-testid` to `CommonProps`.
3. `key` itself (the only current common prop besides `id`) is not even used anywhere at all. This is because our PureScript-side rendering doesn't suffer from the same malady as React proper, where you have to have the `key` always, even if the array is not really logically a list, or even when there are never more than three elements in it, etc. We just end up never using `key` in the first place, except in cases where it's actually a longish list (of which we've had none so far).

The bottom line is, having `CommonProps` centralized like that, and locked in, seems unsustainable.

**Alternative solution**
Instead of `CommonProps`, I propose using `React.cloneElement` (see https://reactjs.org/docs/react-api.html#cloneelement) to add common props "after the fact".

I have proposed this during our initial discussion, but we ended up not going with it for two reasons: (1) we came up with a better way, based on subsets of props, which also solved the "optional" props problem for free, and (2) Peter was concerned about performance.

I hereby posit that the performance concern is vastly outweighed by modularity/maintainability/extensibility concerns, because:
1. React is already doing a lot of shuffling hashes around, an extra call to `cloneElement` here or there would have a negligible impact
2. We never even use the common props in the first place (see about `key` above), so we won't suffer even that tiny impact.

As a bonus, this also gives us an ability to define locally-common props (see ).

______
**Q:** wait, but the docs say that `cloneElement` will preserve `key` of the original element, so we can't use it for `key`, can we?
**A:** the docs do indeed say that, but that's not how it actually works. At first I read it as "preserve the `key` of the original element _if it exists_", but even that is not true: my experiments show that it actually overrides `key` in any case.

**Q** from @gasi: If we’re worried about unnecessary `cloenElement`, we can still define props as first-class citizens, even though there might some duplication, e.g. `testId :: String` on every component that supports it, right?
**A:** Yes, this is always an ugly, yet sound last-resort solution.

**Q** from @gasi: Once we decide to expose all vanilla HTML elements in _Elmish_, can we still do something like `SharedProps` for ‘free’, or will that require `cloneElement` for each element?
**A:** Yes, we can have `SharedProps` for free, by mixing rows, e.g. `type AProps r = ( href :: String, target :: LinkTarget, ... | SharedProps r )`