### PR TITLE
Remove id from CommonProps

### DIFF
--- a/src/Elmish/React/Import.purs
+++ b/src/Elmish/React/Import.purs
@@ -14,7 +14,7 @@ import Prim.Row as Row
 
 -- | Row of props that are common to all React components, without having to
 -- | declare them.
-type CommonProps = ( id :: String, key :: String )
+type CommonProps = ( key :: String )
 
 -- | And empty open row. To be used for components that don't have any optional
 -- | or any required props.


### PR DESCRIPTION
A small change motivated by the same discussion that started https://github.com/collegevine/purescript-elmish/pull/1. Namely that having `id` readily available in `CommonProps` leads to bad design.

Corresponding CV change at https://github.com/collegevine/cv/pull/2787.