### PR TITLE
Allow simple creation of basic Elmish apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Bifunctor`, `Functor`, `Applicative` instances for `Transition`
+- `Bifunctor`, `Functor`, `Applicative` instances for `Transition`.
 - `ComponentReturnCallback` - a CPS-style way of returning polymorphically typed
   components.
+- `Elmish.Browser.sandbox` for creating a sandboxed Elmish app.
 
 ### Changed
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `pureUpdate` in favor of `pure`
+- `pureUpdate` in favor of `pure`.
 
 ## 0.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `(DispatchError -> Effect Unit)` for reporting view errors.
 - `construct` now takes the error-reporting function after execution of the
   effect, to improve composability.
+- Drop redundant `react*` prefix and match React DOM API naming:
+  - Rename and move `Elmish.React.reactMount` to `Elmish.React.DOM.render`
+  - Rename and move `Elmish.React.reactUnmount` to
+    `Elmish.React.DOM.unmountComponentAtNode`.
 
 ### Deprecated
 
@@ -30,4 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.0.4
 
-Initial release
+Initial release.

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "type": "git",
     "url": "https://github.com/collegevine/purescript-elmish.git"
   },
-
   "ignore": [
     "**/.*",
     "node_modules",
@@ -29,7 +28,7 @@
     "purescript-record": "^2.0.0",
     "purescript-tuples": "^5.1.0",
     "purescript-typelevel-prelude": "^4.0.0",
-    "purescript-web-html": "^2.0.0"
+    "purescript-web-html": "^2.1.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -4,8 +4,10 @@ module Elmish
     , module Elmish.JsCallback
     , module Elmish.React
     , module Elmish.Ref
+    , module Elmish.Browser
     ) where
 
+import Elmish.Browser (sandbox)
 import Elmish.Component (ComponentDef, Transition(..), construct, nat, pureUpdate, withTrace, (<$$>))
 import Elmish.Dispatch (DispatchMsg, DispatchMsgFn(..), DispatchError, handle, handleMaybe)
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback0, mkJsCallback)

--- a/src/Elmish/Browser.purs
+++ b/src/Elmish/Browser.purs
@@ -1,0 +1,37 @@
+module Elmish.Browser
+    ( sandbox
+    , module Exported
+    ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Aff (Aff)
+import Effect.Exception (throw)
+import Elmish.Component (ComponentDef, construct)
+import Elmish.Dispatch (dispatchMsgFn)
+import Elmish.React.DOM as ReactDOM
+import Web.DOM.ParentNode (QuerySelector(..)) as Exported
+import Web.DOM.ParentNode (QuerySelector(..), querySelector)
+import Web.HTML (window) as HTML
+import Web.HTML.HTMLDocument (toParentNode) as HTMLDocument
+import Web.HTML.Window (document) as HTML
+
+sandbox :: forall msg state. QuerySelector -> ComponentDef Aff msg state -> Effect Unit
+sandbox selector@(QuerySelector rawSelector) component = do
+    window <- HTML.window
+    documentParentNode <- HTMLDocument.toParentNode <$> HTML.document window
+    mDOMElement <- querySelector selector documentParentNode
+    case mDOMElement of
+        Nothing ->
+            throw $
+                "Couldn’t find any element matching '" <> rawSelector <>
+                "' selector.\
+                \ Please make sure it’s defined in your HTML document."
+        Just domElement -> do
+            renderFn <- construct component
+            let reactElement = renderFn $ dispatchMsgFn onError onMessage
+                onError = throw
+                onMessage = const $ pure unit
+            ReactDOM.render reactElement domElement

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -142,7 +142,7 @@ bindComponent cmpt def stateStrategy onViewError =
                     msg <- cmd
                     liftEffect $ dispatchMsg component $ Right msg
 
--- | Given a ComponentDef, binds that def to a freshly created React class,
+-- | Given a `ComponentDef`, binds that def to a freshly created React class,
 -- | instantiates that class, and returns a rendering function. Note that the
 -- | return type of this function is almost the same as that of
 -- | `ComponentDef::view` - except for state. This is not a coincidence: it is

--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -1,5 +1,4 @@
 const React = require("react")
-const ReactDOM = require("react-dom")
 
 exports.getState = function(component) {
   return function() {
@@ -9,17 +8,6 @@ exports.getState = function(component) {
 exports.setState = function(component, state, callback) {
   return function() {
     component.setState({ s: state }, callback)
-  }
-}
-
-exports.reactMount = function(el, jsxDom) {
-  return function() {
-    ReactDOM.render(jsxDom, el)
-  }
-}
-exports.reactUnmount = function(el) {
-  return function() {
-    ReactDOM.unmountComponentAtNode(el)
   }
 }
 

--- a/src/Elmish/React.purs
+++ b/src/Elmish/React.purs
@@ -8,19 +8,16 @@ module Elmish.React
     , createElement'
     , getState
     , setState
-    , reactMount
-    , reactUnmount
     ) where
 
 import Prelude
 
-import Data.Function.Uncurried (Fn2, Fn3, runFn3)
+import Data.Function.Uncurried (Fn3, runFn3)
 import Data.Nullable (Nullable)
 import Effect (Effect)
 import Prim.RowList (class RowToList, kind RowList, Cons, Nil)
 import Prim.TypeError (Text, class Fail)
 import Unsafe.Coerce (unsafeCoerce)
-import Web.DOM (Element)
 import Elmish.Foreign (class CanPassToJavaScript)
 
 -- | Instantiated subtree of React DOM. JSX syntax produces values of this type.
@@ -108,9 +105,6 @@ instance reactChildrenSingle :: ReactChildren ReactElement where
 
 foreign import getState :: forall state. ReactComponentInstance -> Effect (Nullable state)
 foreign import setState :: forall state. Fn3 ReactComponentInstance state (Effect Unit) (Effect Unit)
-
-foreign import reactMount :: Fn2 Element ReactElement (Effect Unit)
-foreign import reactUnmount :: Element -> Effect Unit
 
 -- This instance allows including `ReactElement` in view arguments.
 instance tojsReactElement :: CanPassToJavaScript ReactElement

--- a/src/Elmish/React.purs
+++ b/src/Elmish/React.purs
@@ -24,7 +24,7 @@ import Elmish.Foreign (class CanPassToJavaScript)
 foreign import data ReactElement :: Type
 
 -- | This type represents constructor of a React component with a particular
--- | behavior. The type prameter is the record of props (in React lingo) that
+-- | behavior. The type parameter is the record of props (in React lingo) that
 -- | this component expects. Such constructors can be "rendered" into
 -- | `ReactElement` via `createElement`.
 foreign import data ReactComponent :: Type -> Type

--- a/src/Elmish/React/DOM.js
+++ b/src/Elmish/React/DOM.js
@@ -1,1 +1,18 @@
-exports.fragment_ = require("react").Fragment
+const React = require("react")
+const ReactDOM = require("react-dom")
+
+
+exports.fragment_ = React.Fragment
+
+exports.render = function(reactElement) {
+  return function(domElement) {
+    return function() {
+      ReactDOM.render(reactElement, domElement)
+    }
+  }
+}
+exports.unmountComponentAtNode = function(domElement) {
+  return function() {
+    ReactDOM.unmountComponentAtNode(domElement)
+  }
+}

--- a/src/Elmish/React/DOM.purs
+++ b/src/Elmish/React/DOM.purs
@@ -2,10 +2,17 @@ module Elmish.React.DOM
     ( empty
     , text
     , fragment
+
+    , render
+    , unmountComponentAtNode
     ) where
 
+import Prelude
+
+import Effect (Effect)
 import Elmish.React (ReactComponent, ReactElement, createElement)
 import Unsafe.Coerce (unsafeCoerce)
+import Web.DOM (Element)
 
 -- | Empty React element.
 empty :: ReactElement
@@ -20,3 +27,6 @@ fragment :: Array ReactElement -> ReactElement
 fragment = createElement fragment_ {}
 
 foreign import fragment_ :: ReactComponent {}
+
+foreign import render :: ReactElement -> Element -> Effect Unit
+foreign import unmountComponentAtNode :: Element -> Effect Unit

--- a/src/Elmish/React/Import.purs
+++ b/src/Elmish/React/Import.purs
@@ -56,7 +56,7 @@ type ImportedReactComponentConstructorWithContent reqProps optProps =
 -- safety is supposed to come from a wrapper function of type
 -- `ImportedReactComponentConstructor` (see above), which would have the
 -- appropriate props constraints.
-type ImportedReactComponent  = forall r. ReactComponent r
+type ImportedReactComponent = forall r. ReactComponent r
 
 
 -- Asserts that one type row is a (non-strict) subset of the other type row


### PR DESCRIPTION
## CHANGELOG

### Added

- `Elmish.Browser.sandbox` for creating a sandboxed Elmish app.

### Changed

- Drop redundant `react*` prefix and match React DOM API naming:
  - Rename and move `Elmish.React.reactMount` to `Elmish.React.DOM.render`
  - Rename and move `Elmish.React.reactUnmount` to
    `Elmish.React.DOM.unmountComponentAtNode`.