### PR TITLE
Upgrade to PureScript 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgraded to PureScript 0.13.0 (see [release noted](https://github.com/purescript/purescript/releases/tag/v0.13.0))
+- Upgraded to PureScript 0.13.0 (see [release notes](https://github.com/purescript/purescript/releases/tag/v0.13.0))
 
 ## 0.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0
+
+### Changed
+
+- Upgraded to PureScript 0.13.0 (see [release noted](https://github.com/purescript/purescript/releases/tag/v0.13.0))
+
 ## 0.0.5
 
 ### Removed

--- a/bower.json
+++ b/bower.json
@@ -22,14 +22,14 @@
     "purescript-argonaut-core": "^5.0.0",
     "purescript-debug": "^4.0.0",
     "purescript-either": "^4.1.1",
-    "purescript-foreign-object": "^2.0.1",
+    "purescript-foreign-object": "^2.0.2",
     "purescript-functions": "^4.0.0",
-    "purescript-maybe": "^4.0.0",
-    "purescript-prelude": "^4.1.0",
-    "purescript-record": "^2.0.0",
+    "purescript-maybe": "^4.0.1",
+    "purescript-prelude": "^4.1.1",
+    "purescript-record": "^2.0.1",
     "purescript-tuples": "^5.1.0",
-    "purescript-typelevel-prelude": "^4.0.0",
-    "purescript-web-html": "^2.0.0"
+    "purescript-typelevel-prelude": "^5.0.0",
+    "purescript-web-html": "^2.2.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"

--- a/elmish.dhall
+++ b/elmish.dhall
@@ -5,13 +5,13 @@ Elmish in their Dahl package set.
 For example:
 
     let upstream =
-          https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190508/src/packages.dhall sha256:8ef3a6d6d123e05933997426da68ef07289e1cbbdd2a844b5d10c9159deef65a
+          https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190611/src/packages.dhall sha256:8ef3a6d6d123e05933997426da68ef07289e1cbbdd2a844b5d10c9159deef65a
 
     let elmish =
           https://raw.githubusercontent.com/collegevine/purescript-elmish/master/elmish.dhall
 
     let additions = {
-      elmish = elmish "v0.0.4"
+      elmish = elmish "v0.1.0"
     }
 
     in  upstream // additions
@@ -19,7 +19,7 @@ For example:
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190508/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190611/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 in
       mkPackage

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,14 +25,14 @@
       "dev": true
     },
     "acorn-node": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.2.tgz",
-      "integrity": "sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.7.0.tgz",
+      "integrity": "sha512-XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
+        "acorn": "^6.1.1",
         "acorn-dynamic-import": "^4.0.0",
-        "acorn-walk": "^6.1.0",
+        "acorn-walk": "^6.1.1",
         "xtend": "^4.0.1"
       }
     },
@@ -562,9 +562,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -886,25 +886,12 @@
       "dev": true
     },
     "feint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.2.tgz",
-      "integrity": "sha512-PC77rn63FAMGcmHEkuGh4AdofqI6/c/YGjyvLo60mGLcCOHUUzCnKFzoij062piVgBblkl/KlN1vHGVJsK88cg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.3.tgz",
+      "integrity": "sha512-BY1jwDlOx4uA9rtn2H9bZSuHT7yyOtSRDVwUwprRpRXvpm1F73gSGuHznEu50lT6epscULOknphOprG9ljoARg==",
       "dev": true,
       "requires": {
-        "append-type": "^1.0.1"
-      }
-    },
-    "file-to-npm-cache": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/file-to-npm-cache/-/file-to-npm-cache-0.1.0.tgz",
-      "integrity": "sha512-2/aq3BD1pkd6b4pafmTaO8EzRCiQKfFmJxg+zKAdDMAcqqJMC0nQYcuCU29say0ZTzXxafKXcJB50N+yb0WIoQ==",
-      "dev": true,
-      "requires": {
-        "inspect-with-kind": "^1.0.5",
-        "is-plain-obj": "^1.1.0",
-        "npcache": "^1.0.0",
-        "pump": "^3.0.0",
-        "tar": "^4.4.6"
+        "append-type": "^1.0.2"
       }
     },
     "filesize": {
@@ -1138,14 +1125,13 @@
       }
     },
     "install-purescript": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.7.0.tgz",
-      "integrity": "sha512-AOmIq8rPEOLn5Bo8RQngvDXWeo6USKIt+28UhcAmQJNvj63MqdNBIQRTgNyypbsniv7d7VWjz53pw2+kTgh3mg==",
+      "version": "0.8.0-0",
+      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.8.0-0.tgz",
+      "integrity": "sha512-aWg52jIOPfzH98UYlrPnXdvqc4o4lon10LCVplKss8kvEIKzn6r8HX5qcRNTsmdPUyCTHd1G/Qrin+KwTQLjZQ==",
       "dev": true,
       "requires": {
         "arch": "^2.1.1",
         "download-or-build-purescript": "^0.3.4",
-        "file-to-npm-cache": "^0.1.0",
         "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0",
         "npcache": "^1.0.2",
@@ -1156,14 +1142,14 @@
       }
     },
     "install-purescript-cli": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.4.2.tgz",
-      "integrity": "sha512-y62GvwsMksz7aSJQsK2pPelmBByp0eDgpI+uFheEU05wpekM6WtCgq7WkTAc+Ar/nt+7Y5lYzGOqSOWnGAEIBQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.5.0.tgz",
+      "integrity": "sha512-72BkCL3C92R/SBfJ5AFXkqh84unJh4ZBLuS70MmyZY63TSJ5qfZRPrbWgBBOxEarRDrMJtLXGv7patoU2bUMCA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "filesize": "^4.1.2",
-        "install-purescript": "^0.7.0",
+        "install-purescript": "0.8.0-0",
         "log-symbols": "^3.0.0",
         "log-update": "^3.2.0",
         "minimist": "^1.2.0",
@@ -1243,22 +1229,13 @@
       "dev": true
     },
     "labeled-stream-splicer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
-      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
-        "isarray": "^2.0.4",
         "stream-splicer": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
-          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
-          "dev": true
-        }
       }
     },
     "load-from-cwd-or-npm": {
@@ -1411,14 +1388,14 @@
       }
     },
     "module-deps": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.0.tgz",
-      "integrity": "sha512-hKPmO06so6bL/ZvqVNVqdTVO8UAYsi3tQWlCa+z9KuWhoN4KDQtb5hcqQQv58qYiDE21wIvnttZEPiDgEbpwbA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
+      "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
         "browser-resolve": "^1.7.0",
-        "cached-path-relative": "^1.0.0",
+        "cached-path-relative": "^1.0.2",
         "concat-stream": "~1.6.0",
         "defined": "^1.0.0",
         "detective": "^5.0.2",
@@ -1466,9 +1443,9 @@
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
@@ -1773,9 +1750,9 @@
       }
     },
     "pulp": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/pulp/-/pulp-12.4.2.tgz",
-      "integrity": "sha512-hU2vADQCh/PJBtVX5rTpSyhHbOopYUZ5QLlgoz0ZBFHjgGY1I9dPBqH5FW5uag9Q1Ewz8OeWHtLDmRtY6w7UlQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/pulp/-/pulp-13.0.0.tgz",
+      "integrity": "sha512-wjjAVuN1Shx6783NvTd8aPwWZ1pE94+isiWtdAJhedvbLqJuwe8p5CSNul9FS0WvBz7ejdrW0vc6wLDLsKX7Yw==",
       "dev": true,
       "requires": {
         "browserify": "^16.2.3",
@@ -1787,7 +1764,6 @@
         "node-static": "^0.7.11",
         "read": "^1.0.7",
         "sorcery": "^0.10.0",
-        "string-stream": "0.0.7",
         "temp": "^0.9.0",
         "through": "^2.3.8",
         "tree-kill": "^1.2.1",
@@ -1812,12 +1788,12 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.12.5.tgz",
-      "integrity": "sha512-L0N0KrRgZm8pXYqT8Dc5m6BzjnYvkOaxx9Tms874NUivm8DYSs3oLtDrnNM8cVrjCCXCvS0g8l73CKNymaL6qw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.0.tgz",
+      "integrity": "sha512-KrhVO8sBLWiMlDqmqyXNV3FieL/wO/V7aokpqs81gmuQ4s/avDKNiZO3SXPG8VQ1i/ZbUfp7jatar/T2FLR8Nw==",
       "dev": true,
       "requires": {
-        "install-purescript-cli": "^0.4.0"
+        "install-purescript-cli": "^0.5.0"
       }
     },
     "purescript-psa": {
@@ -1921,9 +1897,9 @@
       }
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2151,20 +2127,14 @@
       }
     },
     "stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
       }
-    },
-    "string-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/string-stream/-/string-stream-0.0.7.tgz",
-      "integrity": "sha1-z83oJ5n6YvMDQpqqeTNu6INDMv4=",
-      "dev": true
     },
     "string-width": {
       "version": "3.1.0",
@@ -2229,18 +2199,18 @@
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "temp": {
@@ -2407,9 +2377,9 @@
       }
     },
     "win-user-installed-npm-cli-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-3.0.0.tgz",
-      "integrity": "sha512-3b2TY0fmLQmeG3HhHa9I4Rq0ZIJg5SZpr5aB++DuAR1NNO+9ZcMueDZ7XRSynaOyCWTgJDFc+c3tDXaeHSFtAg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-3.0.1.tgz",
+      "integrity": "sha512-Us1ZlMmWDInXihJ+SWP8/L0ArqsLqPtWK9Q67x6+q+z7C2c22viVgCmbH+x0BeMsosmPS9OKHvka519XbO51Rw==",
       "dev": true
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   },
   "devDependencies": {
     "bower": "^1.8.8",
-    "pulp": "12.4.2",
-    "purescript": "0.12.5",
+    "pulp": "^13.0.0",
+    "purescript": "^0.13.0",
     "purescript-psa": "0.7.3"
   }
 }

--- a/src/Elmish/Foreign.purs
+++ b/src/Elmish/Foreign.purs
@@ -30,7 +30,7 @@ import Foreign (Foreign) as ForeignReexport
 import Foreign (Foreign, isArray, isNull, unsafeFromForeign, unsafeToForeign)
 import Foreign.Object as Obj
 import Type.Proxy (Proxy(..))
-import Type.Row (class RowToList, Cons, Nil, RLProxy(RLProxy), kind RowList)
+import Type.RowList (class RowToList, Cons, Nil, RLProxy(RLProxy), kind RowList)
 
 -- | Type of the `arguments` object in a JS function (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments).
 foreign import data Arguments :: Type


### PR DESCRIPTION
One minor breaking change hit us: apparently the structure of `Prim` has changed, which forced me to upgrade `typelevel-prelude`, and while I was at it, I also upgraded all the other dependencies to their latest versions.