### PR TITLE
Transition Bind instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4
+
+### Added
+
+- `Bind` instance for `Transition`, enabling `do`-notation
+- `fork` - a convenience wrapper function for constructing effectful state
+  updates in imperative-ish style
+- Reexports `lmap` and `rmap` from `BiFunctor`
+
 ## 0.1.3
+
+### Added
 
 - Convenience reexports of `bimap`, `(>$<)`, and `(>#<)`
 
 ## 0.1.2
 
-- Add support HTML data attributes via `_data :: Object` API.
+### Added
+
+- Support HTML data attributes via `_data :: Object` API.
 
 ## 0.1.0
 

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -8,7 +8,7 @@ module Elmish
     ) where
 
 import Elmish.Boot (BootResult, boot, boot')
-import Elmish.Component (ComponentDef, Transition(..), bimap, construct, nat, pureUpdate, withTrace, (<$$>))
+import Elmish.Component (ComponentDef, Transition(..), bimap, construct, fork, lmap, nat, pureUpdate, rmap, withTrace, (<$$>))
 import Elmish.Dispatch (DispatchMsg, DispatchMsgFn(..), DispatchError, handle, handleMaybe, (>$<), (>#<))
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback0, mkJsCallback)
 import Elmish.React (ReactComponent, ReactElement, createElement, createElement')

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -51,7 +51,7 @@ import Elmish.Trace (traceTime)
 -- | used:
 -- |
 -- |     update :: State -> Message -> Transition Aff Message State
--- |     update state (ChildMsg m) = do
+-- |     update state (ChildMsg m) =
 -- |         bimap ChildMsg (state { child = _ }) $ Child.update state.child m
 -- |
 data Transition m msg state = Transition state (Array (m msg))

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -40,6 +40,10 @@ instance trApply :: Apply (Transition m msg) where
     apply (Transition f cmds1) (Transition x cmds2) = Transition (f x) (cmds1 <> cmds2)
 instance trApplicative :: Applicative (Transition m msg) where
     pure a = Transition a []
+instance trBind :: Bind (Transition m msg) where
+    bind (Transition s cmds) f =
+        let (Transition s' cmds') = f s
+        in Transition s' (cmds <> cmds')
 
 -- | Definition of a component according to The Elm Architecture. Consists of
 -- | three functions - init, view, update, - that together describe the


### PR DESCRIPTION
This gives the `Transition` type a `Bind` instance, so we can use monadic syntax for collecting effects. See comments [on `fork`](https://github.com/collegevine/purescript-elmish/pull/15/files#diff-12c7a835f986da1ebf52811a88f19bbfR72) and [on `Transition`](https://github.com/collegevine/purescript-elmish/pull/15/files#diff-12c7a835f986da1ebf52811a88f19bbfR35).    