### PR TITLE
Add support for the simplest (toy) entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1
+
+### Added
+
+- `defaultMain` - a convenience entry point for the simplest use case - a single
+  bundle embedded in a single HTML file.
+
 ## 0.2.0
 
 ### Changed


### PR DESCRIPTION
As we added support for SSR, we kind of dropped the simplest use case - where the `main` function of the bundle is supposed to do all the work without any assistance from JS embedded in the page or other such nonsense.

This PR restores such support.