### PR TITLE
Make import of react-dom/server actually safe

### DIFF
--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -7,7 +7,7 @@ exports.setState_ = (component, state, callback) => component.setState({ s: stat
 
 exports.render_ = ReactDOM.render
 exports.hydrate_ = ReactDOM.hydrate
-exports.renderToString = ReactDOMServer ? ReactDOMServer.renderToString : (_ => "")
+exports.renderToString = (ReactDOMServer && ReactDOMServer.renderToString) || (_ => "")
 
 exports.createElement_ = function(component, props, children) {
   // The type of `children` is `Array ReactElement`. If we pass that in as


### PR DESCRIPTION
While working on upgrading our JS bundler I realized that this import of `react-dom/server` wasn't actually safe. When the bundler is instructed to evict this module from the bundle, `require`ing it doesn't return `null` or `undefined`, it returns an empty object. And this would lead to `exports.renderToString = undefined`, which would be bad if it was called from PureScript.

Fortunately this doesn't really matter that much, since we're never actually calling that function from the browser. Still, better safe than sorry :-)