### PR TITLE
Run commands asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2
+
+### Changed
+
+- we now make sure that commands (aka effects) yielded by an `update` call
+  actually run asynchronously
+
 ## 0.2.1
 
 ### Added

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -24,7 +24,7 @@ import Data.Function.Uncurried (Fn2, runFn2)
 import Data.Maybe (Maybe, maybe)
 import Debug.Trace as Trace
 import Effect (Effect, foreachE)
-import Effect.Aff (Aff, launchAff_)
+import Effect.Aff (Aff, Milliseconds(..), delay, launchAff_)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Class.Console as Console
 import Elmish.Dispatch (DispatchError, DispatchMsg, DispatchMsgFn(..), dispatchMsgFn, issueError)
@@ -266,7 +266,8 @@ bindComponent cmpt def stateStrategy onViewError =
         runCmds cmds component = foreachE cmds runCmd
             where
                 runCmd :: Command Aff msg -> Effect Unit
-                runCmd cmd = launchAff_ $
+                runCmd cmd = launchAff_ do
+                    delay $ Milliseconds 0.0 -- Make sure this call is actually async
                     cmd $ \msg -> liftEffect $ dispatchMsg component (Right msg)
 
 -- | Given a ComponentDef, binds that def to a freshly created React class,


### PR DESCRIPTION
We have been sort-of relying on the notion that any effects produced by `fork`/`forkVoid`/`forkMaybe` run asynchronously, but turns out that is not actually the case. 

In reality, PureScript's implementation of `Aff` is carefully crafted not to introduce unnecessary asynchrony in cases where it's not actually required (e.g. waiting on promises or timeouts). In retrospect this makes much sense: if every `bind` in an `Aff` computation was actually async, the computation would be super slow. 

But to my great shame 🤦, this fact has escaped me until recently, when I decided to investigate the slowness of CV Schools Hub. Turns out most of the slowness comes from forking a lot of messages on every interaction, many of which cause heavy stuff to happen, such as school list filtering. Since all those messages ended up happening synchronously, the overall result was a feeling of "sticky" and "clunky".

It is also true that the Hub itself needs to be fixed to prevent unnecessary processing. But Elmish needs to be fixed too.