### PR TITLE
Transition is now a Monad

### DIFF
--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -75,6 +75,7 @@ instance trBind :: Bind (Transition m msg) where
     bind (Transition s cmds) f =
         let (Transition s' cmds') = f s
         in Transition s' (cmds <> cmds')
+instance trMonad :: Monad (Transition m msg)
 
 -- | Smart constructor for the `Transition` type. See comments there. This
 -- | function takes the new (i.e. updated) state and an array of commands - i.e.


### PR DESCRIPTION
When we originally empowered `Transition`, we implemented up to `Bind`, but never implemented `Monad`.

`Bind` alone is enough for using the `do` notation, but the absence of `Monad` turns out to be preventing more complex stuff, such as monad transformers.