### PR TITLE
Simplify Dispatch drastically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0
+
+## Removed
+
+- **Breaking**: `DispatchMsgFn` (replaced with `Dispatch`) and friends -
+  `issueMsg`, `issueError`, `cmapMaybe`, `dispatchMsgFn`, `ignoreMsg`.
+- **Breaking**: Dispatch can no longer report errors due to failed decoding of
+  parameters passed from JavaScript. This feature turned out to be nearly
+  useless, yet it was creating quite a bit of extra complexity.
+
+## Changed
+
+- **Breaking**: `handle` and `handleMaybe` are no longer variadic. They only
+  work with single-argument event handler, which is the most common case. Since
+  `Dispatch` is now just a function, other cases can be easily covered via
+  `mkEffectFnX` (for which both `handle` and `handleMaybe` are no facades).
+
+## Added
+
+- **Breaking**: `Dispatch` (replaces `DispatchMsgFn`) - just an alias for `msg -> Effect Unit` now
+- `<|` alias for `handle`
+- `<?|` alias for `handleMaybe`
+- `CanPassToJavaScript` instances for `Effect Unit`, `EffectFn1 a Unit`, and
+  `EffectFn2 a b Unit`, so they can be used as event handlers.
+
 ## 0.4.0
 
 ### Changed

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -8,6 +8,6 @@ module Elmish
 
 import Elmish.Boot (BootRecord, boot)
 import Elmish.Component (ComponentDef, Transition(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
-import Elmish.Dispatch (Dispatch, EffectFn1, EffectFn2, handle, handleMaybe, mkEffectFn1, mkEffectFn2)
+import Elmish.Dispatch (Dispatch, EffectFn1, EffectFn2, handle, handleMaybe, mkEffectFn1, mkEffectFn2, (<|), (<?|))
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback)
 import Elmish.React (ReactComponent, ReactElement, createElement, createElement')

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -8,6 +8,6 @@ module Elmish
 
 import Elmish.Boot (BootRecord, boot)
 import Elmish.Component (ComponentDef, Transition(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
-import Elmish.Dispatch (DispatchMsg, DispatchMsgFn(..), DispatchError, handle, handleMaybe, (>$<), (>#<))
+import Elmish.Dispatch (Dispatch, handle, handleMaybe)
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback)
 import Elmish.React (ReactComponent, ReactElement, createElement, createElement')

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -8,6 +8,6 @@ module Elmish
 
 import Elmish.Boot (BootRecord, boot)
 import Elmish.Component (ComponentDef, Transition(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
-import Elmish.Dispatch (Dispatch, handle, handleMaybe)
+import Elmish.Dispatch (Dispatch, EffectFn1, EffectFn2, handle, handleMaybe, mkEffectFn1, mkEffectFn2)
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback)
 import Elmish.React (ReactComponent, ReactElement, createElement, createElement')

--- a/src/Elmish/Boot.purs
+++ b/src/Elmish/Boot.purs
@@ -11,7 +11,6 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Class.Console as Console
 import Elmish.Component as Comp
-import Elmish.Dispatch (Dispatch)
 import Elmish.React as React
 import Web.DOM.NonElementParentNode (getElementById) as DOM
 import Web.HTML (window) as DOM
@@ -107,7 +106,7 @@ boot mkDef =
   , hydrate: mountVia React.hydrate
   }
   where
-    renderToString props = React.renderToString $ def.view state0 onError
+    renderToString props = React.renderToString $ def.view state0 (const $ pure unit)
       where
         def = mkDef props
         Comp.Transition state0 _ = def.init
@@ -122,10 +121,6 @@ boot mkDef =
         Just e -> do
           render <- Comp.construct (mkDef props)
           f render e
-
-    onError :: forall a. Dispatch a
-    onError _ = pure unit
-
 
 -- | This function supports the simplest (almost toy?) use case where there is
 -- | no server, no server-side rendering, all that exists is an HTML page that

--- a/src/Elmish/Boot.purs
+++ b/src/Elmish/Boot.purs
@@ -11,7 +11,7 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Class.Console as Console
 import Elmish.Component as Comp
-import Elmish.Dispatch (DispatchMsgFn, dispatchMsgFn)
+import Elmish.Dispatch (Dispatch)
 import Elmish.React as React
 import Web.DOM.NonElementParentNode (getElementById) as DOM
 import Web.HTML (window) as DOM
@@ -121,10 +121,10 @@ boot mkDef =
           Console.error $ "Element #" <> domElementId <> " not found"
         Just e -> do
           render <- Comp.construct (mkDef props)
-          f (render onError) e
+          f render e
 
-    onError :: forall a. DispatchMsgFn a
-    onError = dispatchMsgFn Console.error (const $ pure unit)
+    onError :: forall a. Dispatch a
+    onError _ = pure unit
 
 
 -- | This function supports the simplest (almost toy?) use case where there is

--- a/src/Elmish/Dispatch.purs
+++ b/src/Elmish/Dispatch.purs
@@ -1,151 +1,23 @@
 module Elmish.Dispatch
-    ( DispatchMsgFn(..)
-    , DispatchMsg
-    , DispatchError
-    , dispatchMsgFn
-    , issueError
-    , issueMsg
-    , ignoreMsg
-    , cmapMaybe
+    ( Dispatch
     , handle
     , handleMaybe
-    , class MkEventHandler
-    , mkEventHandler
-    , module Contravariant
     ) where
 
 import Prelude
 
-import Data.Bifunctor (rmap)
-import Data.Either (Either(..), either)
-import Data.Functor.Contravariant ((>$<), (>#<)) as Contravariant
-import Data.Functor.Contravariant (class Contravariant)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe, maybe)
 import Effect (Effect)
-import Elmish.JsCallback (class MkJsCallback, JsCallback, jsCallback')
+import Effect.Uncurried (EffectFn1, mkEffectFn1)
 
--- TODO: legacy placeholder. Remove.
-type DispatchMsg = Effect Unit
+-- | A function that a view can use to report messages originating from JS/DOM.
+type Dispatch msg = msg -> Effect Unit
 
--- | Represents a function that a view can use to report both errors and
--- | messages originating from JS/DOM. Underneath it's just a function that
--- | takes an `Either`, but it is wrapped in a newtype in order to provide class
--- | instances for it.
-newtype DispatchMsgFn msg = DispatchMsgFn (Either DispatchError msg -> Effect Unit)
+infixr 9 handle as <|
+infixr 9 handleMaybe as <?|
 
-instance contravariantDispatch :: Contravariant DispatchMsgFn where
-    cmap f (DispatchMsgFn dispatch) = DispatchMsgFn $ dispatch <<< rmap f
+handle :: forall arg msg. Dispatch msg -> (arg -> msg) -> EffectFn1 arg Unit
+handle dispatch fn = mkEffectFn1 $ dispatch <<< fn
 
--- | Construct a `DispatchMsgFn` out of "on error" and "on message" handlers
-dispatchMsgFn :: forall msg. (DispatchError -> Effect Unit) -> (msg -> Effect Unit) -> DispatchMsgFn msg
-dispatchMsgFn onErr onMsg = DispatchMsgFn $ either onErr onMsg
-
--- | Report an error via the given dispatch function
-issueError :: forall msg. DispatchMsgFn msg -> DispatchError -> Effect Unit
-issueError (DispatchMsgFn d) = d <<< Left
-
--- | Issue a message via the given dispatch function
-issueMsg :: forall msg. DispatchMsgFn msg -> msg -> Effect Unit
-issueMsg (DispatchMsgFn d) = d <<< Right
-
--- | Creates a new `DispatchMsgFn` that relays errors from the given
--- | `DispatchMsgFn`, but throws away messages
-ignoreMsg :: forall msg1 msg2. DispatchMsgFn msg1 -> DispatchMsgFn msg2
-ignoreMsg = cmapMaybe $ const Nothing
-
--- | Allows to optionally convert the message to another type, swallowing the
--- | message when conversion fails.
-cmapMaybe :: forall msg1 msg2
-     . (msg2 -> Maybe msg1)
-    -> DispatchMsgFn msg1
-    -> DispatchMsgFn msg2
-cmapMaybe f (DispatchMsgFn d) =
-    DispatchMsgFn \msg2 -> case f <$> msg2 of
-        Left err -> d $ Left err
-        Right (Just msg1) -> d $ Right msg1
-        Right Nothing -> pure unit
-
--- TODO: refine this
-type DispatchError = String
-
--- | Creates a `JsCallback` that uses the given `DispatchMsgFn` to either issue
--- | a message or report an error. The `fn` parameter is either a message or a
--- | function that produces a message. When the JS code calls the resulting
--- | `JsCallback`, its parameters are validated, then the `fn` function is
--- | called to produce a message, which is then reported via the given
--- | `DispatchMsgFn`, unless the parameters passed from JS cannot be decoded, in
--- | which case an error is reported via `DispatchMsgFn`.
--- |
--- | Example of intended usage with `elmish-html`:
--- |
--- |      -- PureScript
--- |      data Message = A | B Int
--- |
--- |      view state dispatch =
--- |        div {}
--- |        [ button { onClick: handle dispatch A } "Click A"
--- |        , button { onClick: handle dispatch $ B 42 } "Click B"
--- |        ]
--- |
--- | Example with FFIed component used as the view:
--- |
--- |      -- PureScript
--- |      data Message = A | B Int | C String Boolean
--- |
--- |      view state dispatch = createElement' ffiComponent_
--- |          { foo: "bar"
--- |          , onA: handle dispatch A
--- |          , onB: handle dispatch B
--- |          , onC: handle dispatch C
--- |          , onBaz: handle dispatch \x y -> B (x+y)
--- |          }
--- |
--- |      // JSX:
--- |      export const ffiComponent_ = args =>
--- |          <div>
--- |              Foo is {args.bar}<br />
--- |              <button onClick={args.onA}>A</button>
--- |              <button onClick={() => args.onB(42)}>B</button>
--- |              <button onClick={() => args.onC("hello", true)}>C</button>
--- |              <button onClick={() => args.onBaz(21, 21)}>Baz</button>
--- |          </div>
--- |
-handle :: forall msg fn effFn
-     . MkEventHandler msg fn effFn
-    => MkJsCallback effFn
-    => DispatchMsgFn msg
-    -> fn
-    -> JsCallback effFn
-handle (DispatchMsgFn dispatch) fn =
-    jsCallback' (mkEventHandler fn onMessage) onError
-    where
-        onMessage = dispatch <<< Right
-        onError = dispatch <<< Left <<< show
-
--- | A version of `handle` (see comments there) with a possibility of not
--- | producing a message.
-handleMaybe :: forall msg fn effFn
-     . MkEventHandler (Maybe msg) fn effFn
-    => MkJsCallback effFn
-    => DispatchMsgFn msg
-    -> fn
-    -> JsCallback effFn
-handleMaybe d = handle $ cmapMaybe identity d
-
-
--- | This type class and its instances are implementation of `handle` and
--- | `handleMaybe`. The base case is when `fn ~ msg` - that is when the
--- | message-producing function is not a function at all, but the message
--- | itself. The recursive instance prepends an argument `a`, thus allowing for
--- | curried functions with arbitrary number of parameters.
-class MkEventHandler msg fn effFn | fn -> effFn, effFn -> fn where
-    mkEventHandler ::
-        fn                          -- ^ Either a message or a function that produces a message.
-        -> (msg -> Effect Unit)     -- ^ The effect that is to be performed when this handler is invoked.
-        -> effFn                    -- ^ An effectful function suitable for `mkJsCallback`
-
-instance eventHandlerParameter :: MkEventHandler msg fn0 effFn0 => MkEventHandler msg (a -> fn0) (a -> effFn0) where
-    mkEventHandler f dispatch a = mkEventHandler (f a) dispatch
-
-else instance eventHandlerParameterless :: MkEventHandler msg msg (Effect Unit) where
-    mkEventHandler msg dispatch = dispatch msg
+handleMaybe :: forall arg msg. Dispatch msg -> (arg -> Maybe msg) -> EffectFn1 arg Unit
+handleMaybe dispatch fn = mkEffectFn1 $ maybe (pure unit) dispatch <<< fn

--- a/src/Elmish/Dispatch.purs
+++ b/src/Elmish/Dispatch.purs
@@ -2,13 +2,14 @@ module Elmish.Dispatch
     ( Dispatch
     , handle
     , handleMaybe
+    , module E
     ) where
 
 import Prelude
 
 import Data.Maybe (Maybe, maybe)
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, mkEffectFn1)
+import Effect.Uncurried (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2) as E
 
 -- | A function that a view can use to report messages originating from JS/DOM.
 type Dispatch msg = msg -> Effect Unit
@@ -16,8 +17,8 @@ type Dispatch msg = msg -> Effect Unit
 infixr 9 handle as <|
 infixr 9 handleMaybe as <?|
 
-handle :: forall arg msg. Dispatch msg -> (arg -> msg) -> EffectFn1 arg Unit
-handle dispatch fn = mkEffectFn1 $ dispatch <<< fn
+handle :: forall arg msg. Dispatch msg -> (arg -> msg) -> E.EffectFn1 arg Unit
+handle dispatch fn = E.mkEffectFn1 $ dispatch <<< fn
 
-handleMaybe :: forall arg msg. Dispatch msg -> (arg -> Maybe msg) -> EffectFn1 arg Unit
-handleMaybe dispatch fn = mkEffectFn1 $ maybe (pure unit) dispatch <<< fn
+handleMaybe :: forall arg msg. Dispatch msg -> (arg -> Maybe msg) -> E.EffectFn1 arg Unit
+handleMaybe dispatch fn = E.mkEffectFn1 $ maybe (pure unit) dispatch <<< fn

--- a/src/Elmish/Dispatch.purs
+++ b/src/Elmish/Dispatch.purs
@@ -2,6 +2,8 @@ module Elmish.Dispatch
     ( Dispatch
     , handle
     , handleMaybe
+    , (<|)
+    , (<?|)
     , module E
     ) where
 
@@ -17,8 +19,27 @@ type Dispatch msg = msg -> Effect Unit
 infixr 9 handle as <|
 infixr 9 handleMaybe as <?|
 
+-- | A convenience function to make construction of event handlers with
+-- | arguments (i.e. `EffectFn1`) a bit shorter. The function takes a `Dispatch`
+-- | and a mapping from the event argument to a message which the given
+-- | `Dispatch` accepts, and it's also available in operator form.
+-- |
+-- | The following example demonstrates expected usage of both `handle` (in its
+-- | operator form `<|`) and `handleMaybe` (in its operator form `<?|`):
+-- |
+-- |     textarea
+-- |       { value: state.text
+-- |       , onChange: dispatch <?| \e -> TextChanged <$> eventTargetValue e
+-- |       , onMouseDown: dispatch <| \_ -> TextareaClicked
+-- |       }
+-- |
+-- |       where
+-- |         eventTargetValue = readForeign >=> lookup "target" >=> readForeign >=> lookup "value"
+-- |
 handle :: forall arg msg. Dispatch msg -> (arg -> msg) -> E.EffectFn1 arg Unit
 handle dispatch fn = E.mkEffectFn1 $ dispatch <<< fn
 
+-- | Same as `handle`, but dispatches a message optionally. See comments on
+-- | `handle` for an example.
 handleMaybe :: forall arg msg. Dispatch msg -> (arg -> Maybe msg) -> E.EffectFn1 arg Unit
 handleMaybe dispatch fn = E.mkEffectFn1 $ maybe (pure unit) dispatch <<< fn

--- a/src/Elmish/Foreign.purs
+++ b/src/Elmish/Foreign.purs
@@ -125,6 +125,10 @@ instance tojsInt :: CanPassToJavaScript Int
 instance fromjsInt :: CanReceiveFromJavaScript Int where
     isForeignOfCorrectType _ v = isNumber v && (isJust $ fromNumber $ unsafeFromForeign v)
 
+instance tojsEffect :: CanPassToJavaScript a => CanPassToJavaScript (Effect a)
+instance fromjsEffect :: CanReceiveFromJavaScript (Effect Unit) where
+    isForeignOfCorrectType _ = isFunction
+
 instance tojsEffectFn1 :: (CanReceiveFromJavaScript a, CanPassToJavaScript b) => CanPassToJavaScript (EffectFn1 a b)
 instance fromjsEffectFn1 :: CanPassToJavaScript a => CanReceiveFromJavaScript (EffectFn1 a Unit) where
     isForeignOfCorrectType _ = isFunction

--- a/src/Elmish/Foreign.purs
+++ b/src/Elmish/Foreign.purs
@@ -125,15 +125,18 @@ instance tojsInt :: CanPassToJavaScript Int
 instance fromjsInt :: CanReceiveFromJavaScript Int where
     isForeignOfCorrectType _ v = isNumber v && (isJust $ fromNumber $ unsafeFromForeign v)
 
-instance tojsEffect :: CanPassToJavaScript a => CanPassToJavaScript (Effect a)
+instance tojsEffectUnit :: CanPassToJavaScript (Effect Unit)
+else instance tojsEffect :: CanPassToJavaScript a => CanPassToJavaScript (Effect a)
 instance fromjsEffect :: CanReceiveFromJavaScript (Effect Unit) where
     isForeignOfCorrectType _ = isFunction
 
-instance tojsEffectFn1 :: (CanReceiveFromJavaScript a, CanPassToJavaScript b) => CanPassToJavaScript (EffectFn1 a b)
+instance tojsEffectFn1Unit :: CanReceiveFromJavaScript a => CanPassToJavaScript (EffectFn1 a Unit)
+else instance tojsEffectFn1 :: (CanReceiveFromJavaScript a, CanPassToJavaScript b) => CanPassToJavaScript (EffectFn1 a b)
 instance fromjsEffectFn1 :: CanPassToJavaScript a => CanReceiveFromJavaScript (EffectFn1 a Unit) where
     isForeignOfCorrectType _ = isFunction
 
-instance tojsEffectFn2 :: (CanReceiveFromJavaScript a, CanReceiveFromJavaScript b, CanPassToJavaScript c) => CanPassToJavaScript (EffectFn2 a b c)
+instance tojsEffectFn2Unit :: CanReceiveFromJavaScript a => CanPassToJavaScript (EffectFn2 a b Unit)
+else instance tojsEffectFn2 :: (CanReceiveFromJavaScript a, CanReceiveFromJavaScript b, CanPassToJavaScript c) => CanPassToJavaScript (EffectFn2 a b c)
 instance fromjsEffectFn2 :: (CanPassToJavaScript a, CanPassToJavaScript b) => CanReceiveFromJavaScript (EffectFn2 a b Unit) where
     isForeignOfCorrectType _ = isFunction
 

--- a/src/Elmish/JsCallback.purs
+++ b/src/Elmish/JsCallback.purs
@@ -1,3 +1,5 @@
+-- | This module is semi-deprecated and currently unused within Elmish. It will
+-- | probably be resurrected as an optional-validation library.
 module Elmish.JsCallback
     ( JsCallback
     , JsCallback0


### PR DESCRIPTION
## Overview

This PR renames `DispatchMsgFn` to `Dispatch` and changes it from a custom type to alias for `msg -> Effect Unit`. 

The original idea behind making it a custom type was that it could report not only messages originating from the dark JS underworld, but also errors due to mistyped event parameters. This feature was seen as necessary in the early days, when we had a lot of JS and JSX code and it would sometimes contain bugs, giving us unexpected types. 

However, this did not work out in practice: even in those dark times I can only remember a couple of cases where this validation logic actually caught a bug. And today we have moved to PureScript-written views entirely, completely obviating the need for parameter validation. So this error-reporting feature is now completely useless, yet it continues to create quite a bit of complexity.

In addition, as we begin to utilize `wrapWithLocalState` more and more, creating nested components with their own event loops, we begin to more and more frequently see the need to issue several messages on several different event loops at once. This creates some awkwardness with extra `jsCallback` and `issueMsg` calls. Turning `Dispatch` into just an effectful function eliminates this issue entirely.

## Examples of use sites

### Event handler without parameters (e.g. `onClick`, `onBlur`)
* **Before**: `button { onClick: handle dispatch Clicked }`
* **After**: `button { onClick: dispatch Clicked }`
* [Example in `elmish-examples`](https://github.com/collegevine/purescript-elmish-examples/pull/35/files#diff-dfdb32cfc49df12d55da1b65c453f31a49b9b8641006e871dc3b653fa3f2f36bL29-R30)

### Event handler with parameters (e.g. `onChange`)
* **Before**: 
    * Non-optional: `div { onMouseDown: handle dispatch $ const MouseDown }`
    * Optional: `textarea { onChange: handleMaybe dispatch \e -> TextChanged <$> eventTargetValue e }`
* **After**: 
    * `handle` and `handleMaybe` still work with the exact same syntax, but they also have operator forms now - `<|` and `<?|` respectively.
    * Non-optional: `div { onMouseDown: dispatch <| const MouseDown }`
    * Optional: `textarea { onChange: dispatch <?| \e -> TextChanged <$> eventTargetValue e }`
* [Example in `elmish-examples`](https://github.com/collegevine/purescript-elmish-examples/pull/35/files#diff-af37c319d71372b195967f17fa2fdcd788bfc43d7e607ceec3358dee05b5fd4aL205-R206)

## Dispatch composition (i.e. child components)
* **Before**: `Child.view childState (dispatch >#< ChildMsg)`
* **After**: `Child.view childState (dispatch <<< ChildMsg)`
* [Example in `elmish-html`](https://github.com/collegevine/purescript-elmish-examples/pull/35/files#diff-6ad0dd1bee6f166ca03470932347797a15f1a3a8f9aac924dd1eaaee8e44f29cL38-R38)

## Kicking several different event loops (biggest impact)

**Before**
```
onClick: jsCallback do
  issueMsg dispatch Clicked
  issueMsg args.onCommit unit
```

**After**
```
onClick: dispatch Clicked *> args.onCommit
```