### PR TITLE
Update debug dependency for v5.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
         "purescript-aff": "^v6.0.0",
         "purescript-argonaut-core": "^v6.0.0",
         "purescript-console": "^v5.0.0",
-        "purescript-debug": "^v4.0.1",
         "purescript-either": "^v5.0.0",
         "purescript-foreign-object": "^v3.0.0",
         "purescript-functions": "^v5.0.0",
@@ -27,5 +26,8 @@
         "purescript-tuples": "^v6.0.0",
         "purescript-typelevel-prelude": "^v6.0.0",
         "purescript-web-html": "^v3.0.0"
+    },
+    "devDependencies": {
+        "purescript-debug": "^v5.0.0",
     }
 }


### PR DESCRIPTION
`debug` v5.0.0 is out, and I've moved it over to your dev dependencies as I am assuming it shouldn't be used in the published library code. Also see:

https://github.com/purescript/package-sets/pull/863