### PR TITLE
Use Aff by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.6
+
+### Changed
+
+- `ComponentDef` renamed to `ComponentDef'`
+- Added `ComponentDef` as type alias for `ComponentDef' Aff`
+- `Transition` renamed to `Transition'`
+- Added `Transition` as type alias for `Transition' Aff`
+
 ## 0.5.5
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `ComponentDef` renamed to `ComponentDef'`
-- Added `ComponentDef` as type alias for `ComponentDef' Aff`
-- `Transition` renamed to `Transition'`
-- Added `Transition` as type alias for `Transition' Aff`
+- **Breaking**: `ComponentDef` renamed to `ComponentDef'`.
+- Added `ComponentDef` as type alias for `ComponentDef' Aff`.
+- **Breaking**: `Transition` renamed to `Transition'`.
+- Added `Transition` as type alias for `Transition' Aff`.
 
 ## 0.5.5
 

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -7,7 +7,7 @@ module Elmish
     ) where
 
 import Elmish.Boot (BootRecord, boot)
-import Elmish.Component (ComponentDef, Transition(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
+import Elmish.Component (ComponentDef, ComponentDef', Transition, Transition'(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
 import Elmish.Dispatch (Dispatch, EffectFn1, EffectFn2, handle, handleMaybe, mkEffectFn1, mkEffectFn2, (<|), (<?|))
 import Elmish.JsCallback (JsCallback, JsCallback0, jsCallback)
 import Elmish.React (ReactComponent, ReactElement, createElement, createElement')

--- a/src/Elmish/Boot.purs
+++ b/src/Elmish/Boot.purs
@@ -8,7 +8,6 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Effect.Aff (Aff)
 import Effect.Class.Console as Console
 import Elmish.Component as Comp
 import Elmish.React as React
@@ -18,7 +17,7 @@ import Web.HTML.HTMLDocument (toNonElementParentNode) as DOM
 import Web.HTML.Window (document) as DOM
 
 -- | Support for the most common case entry point - i.e. mounting an Elmish
--- | component (i.e. `ComponentDef` structure) to an HTML DOM element with a
+-- | component (i.e. `ComponentDef'` structure) to an HTML DOM element with a
 -- | known ID, with support for server-side rendering.
 -- |
 -- | The function `boot` returns what we call `BootRecord` - a record of three
@@ -57,7 +56,7 @@ import Web.HTML.Window (document) as DOM
 -- |
 -- |     type Props = { hello :: String, world :: Int }
 -- |
--- |     component :: Props -> ComponentDef Aff Message State
+-- |     component :: Props -> ComponentDef' Aff Message State
 -- |     component = ...
 -- |
 -- |     bootRecord :: BootRecord Props
@@ -99,7 +98,7 @@ type BootRecord props =
 
 
 -- | Creates a boot record for the given component. See comments for `BootRecord`.
-boot :: forall msg state props. (props -> Comp.ComponentDef Aff msg state) -> BootRecord props
+boot :: forall msg state props. (props -> Comp.ComponentDef msg state) -> BootRecord props
 boot mkDef =
   { mount: mountVia React.render
   , renderToString
@@ -138,7 +137,7 @@ boot mkDef =
 -- |     main :: Effect Unit
 -- |     main = Boot.defaultMain { elementId: "app", def: def }
 -- |
-defaultMain :: forall msg state. { elementId :: String, def :: Comp.ComponentDef Aff msg state } -> Effect Unit
+defaultMain :: forall msg state. { elementId :: String, def :: Comp.ComponentDef msg state } -> Effect Unit
 defaultMain { elementId, def } =
     bootRec.mount elementId unit
     where

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -58,6 +58,7 @@ import Elmish.Trace (traceTime)
 -- |
 data Transition' m msg state = Transition state (Array (Command m msg))
 
+-- A `Transition'` in which the effects run in `Aff`.
 type Transition msg state = Transition' Aff msg state
 
 -- | An effect that is launched as a result of a component state transition.
@@ -184,6 +185,7 @@ type ComponentDef' m msg state = {
     update :: state -> msg -> Transition' m msg state
 }
 
+-- | A `ComponentDef'` in which effects run in `Aff`.
 type ComponentDef msg state = ComponentDef' Aff msg state
 
 -- | A callback used to return multiple components of different types. See below


### PR DESCRIPTION
Renames `ComponentDef` to `ComponentDef'` and `Transition` to `Transition'` so that `ComponentDef` and `Transition` can be aliases where the monad is `Aff`. Using `Aff` by default should be more beginner-friendly.