### PR TITLE
Fix a bug with initial state in wrapWithLocalState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.7
+
+## Changed
+
+- Fixed a bug related to maintaining state in `wrapWithLocalState`. See [#50](https://github.com/collegevine/purescript-elmish/pull/50).
+
+## Added
+
+- Integration tests powered by [enzyme](https://enzymejs.github.io/enzyme/)
+
 ## 0.5.6
 
 ### Changed

--- a/packages.dhall
+++ b/packages.dhall
@@ -3,10 +3,11 @@ let upstream =
 
 in  upstream
 
-      -- NOTE: We have to remove Elmish itself from dependencies, otherwise
-      -- Spago will install another copy of Elmish from the package set, and
-      -- we'll end up with two copies of Elmish, leading to module name
-      -- conflicts during compilation.
+      -- `elmish-enzyme` and `elmish-html` are used in integration tests.
+      -- Because they both depend on Elmish, we have to remove Elmish from their
+      -- dependencies, otherwise Spago will install another copy of Elmish from
+      -- the package set, and we'll end up with two copies of Elmish, leading to
+      -- module name conflicts during compilation.
       with elmish-enzyme = {
             dependencies = ["prelude"],
             repo = "https://github.com/collegevine/purescript-elmish-enzyme.git",

--- a/src/Elmish/Component.js
+++ b/src/Elmish/Component.js
@@ -16,13 +16,19 @@ exports.withFreshComponent = function(f) {
 exports.instantiateBaseComponent = React.createElement
 
 function mkFreshComponent() {
-  function ElmishComponent() {}
-  ElmishComponent.prototype = Object.create(React.Component.prototype)
-  ElmishComponent.prototype.render = function() {
-    return this.props.render(this)()
-  }
-  ElmishComponent.prototype.componentDidMount = function() {
-    this.props.componentDidMount(this)()
+  class ElmishComponent extends React.Component {
+    constructor(props) {
+      super(props)
+      props.init && props.init(this)()
+    }
+
+    render() {
+      return this.props.render(this)()
+    }
+
+    componentDidMount() {
+      this.props.componentDidMount(this)()
+    }
   }
 
   return ElmishComponent

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -233,11 +233,11 @@ bindComponent :: forall msg state
     -> StateStrategy state           -- ^ Strategy of storing state
     -> ReactElement
 bindComponent cmpt def stateStrategy =
-    runFn2 instantiateBaseComponent cmpt { render, componentDidMount: runCmds initialCmds }
+    runFn2 instantiateBaseComponent cmpt { init: initialize, render, componentDidMount: runCmds initialCmds }
     where
         Transition initialState initialCmds = def.init
 
-        {getState, setState} = stateStrategy {initialState}
+        {initialize, getState, setState} = stateStrategy {initialState}
 
         render :: ReactComponentInstance -> Effect ReactElement
         render component = do
@@ -350,8 +350,9 @@ newtype ComponentName = ComponentName String
 --
 
 -- Props for the React component that is used as base for this framework. The
--- component itself is defined in `./ComponentClass.js`
+-- component itself is defined in the foreign module.
 type BaseComponentProps = {
+    init :: ReactComponentInstance -> Effect Unit,
     render :: ReactComponentInstance -> Effect ReactElement,
     componentDidMount :: ReactComponentInstance -> Effect Unit
 }

--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -4,6 +4,7 @@ const ReactDOMServer = require("react-dom/server")
 
 exports.getState_ = component => component.state && component.state.s
 exports.setState_ = (component, state, callback) => component.setState({ s: state }, callback)
+exports.assignState_ = (component, state) => component.state = { s: state }
 
 exports.render_ = ReactDOM.render
 exports.hydrate_ = ReactDOM.hydrate

--- a/src/Elmish/React.purs
+++ b/src/Elmish/React.purs
@@ -132,7 +132,7 @@ setState :: forall state. ReactComponentInstance -> state -> (Effect Unit) -> Ef
 setState = runEffectFn3 setState_
 foreign import setState_ :: forall state. EffectFn3 ReactComponentInstance state (Effect Unit) Unit
 
--- | The equivalent of `this.state = x`, as opposed to `setStae`, which is the
+-- | The equivalent of `this.state = x`, as opposed to `setState`, which is the
 -- | equivalent of `this.setState(x)`. This function is used in a component's
 -- | constructor to set the initial state.
 assignState :: forall state. ReactComponentInstance -> state -> Effect Unit

--- a/src/Elmish/React.purs
+++ b/src/Elmish/React.purs
@@ -4,6 +4,7 @@ module Elmish.React
     , ReactComponentInstance
     , class ValidReactProps, class ValidReactPropsRL
     , class ReactChildren, asReactChildren
+    , assignState
     , createElement
     , createElement'
     , getState
@@ -130,6 +131,13 @@ foreign import getState_ :: forall state. EffectFn1 ReactComponentInstance (Null
 setState :: forall state. ReactComponentInstance -> state -> (Effect Unit) -> Effect Unit
 setState = runEffectFn3 setState_
 foreign import setState_ :: forall state. EffectFn3 ReactComponentInstance state (Effect Unit) Unit
+
+-- | The equivalent of `this.state = x`, as opposed to `setStae`, which is the
+-- | equivalent of `this.setState(x)`. This function is used in a component's
+-- | constructor to set the initial state.
+assignState :: forall state. ReactComponentInstance -> state -> Effect Unit
+assignState = runEffectFn2 assignState_
+foreign import assignState_ :: forall state. EffectFn2 ReactComponentInstance state Unit
 
 render :: ReactElement -> HTML.Element -> Effect Unit
 render = runEffectFn2 render_

--- a/src/Elmish/State.purs
+++ b/src/Elmish/State.purs
@@ -6,11 +6,11 @@ module Elmish.State
 
 import Prelude
 
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Nullable (toMaybe)
 import Effect (Effect)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
-import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Nullable (toMaybe)
 import Elmish.React as React
 
 -- | This type represents a strategy of storing UI component state. The strategy
@@ -32,16 +32,20 @@ import Elmish.React as React
 -- | of components.
 type StateStrategy state =
     { initialState :: state }
-    -> {
-        getState ::
-            React.ReactComponentInstance -- ^ component instance for which to get the state
-            -> Effect state,
+    ->
+    { initialize ::
+        React.ReactComponentInstance -- ^ component instance for which to initialize the state
+        -> Effect Unit
 
-        setState ::
-            React.ReactComponentInstance -- ^ component instance for which to set the state
-            -> state               -- ^ state to set
-            -> Effect Unit         -- ^ callback to invoke when the operation is complete
-            -> Effect Unit
+    , getState ::
+        React.ReactComponentInstance -- ^ component instance for which to get the state
+        -> Effect state
+
+    , setState ::
+        React.ReactComponentInstance -- ^ component instance for which to set the state
+        -> state               -- ^ state to set
+        -> Effect Unit         -- ^ callback to invoke when the operation is complete
+        -> Effect Unit
     }
 
 
@@ -51,25 +55,28 @@ dedicatedStorage :: forall state. Effect (StateStrategy state)
 dedicatedStorage = mkStrategy <$> Ref.new Nothing
     where
     mkStrategy :: Ref (Maybe state) -> StateStrategy state
-    mkStrategy stateVar {initialState} = {
+    mkStrategy stateVar {initialState} =
+      { initialize: \_ -> pure unit
 
-        getState: \_ -> fromMaybe initialState <$> Ref.read stateVar,
+      , getState: \_ -> fromMaybe initialState <$> Ref.read stateVar
 
-        setState: \c s cb -> do
+      , setState: \c s cb -> do
             Ref.write (Just s) stateVar
             React.setState c s (pure unit)
             cb
-    }
+      }
 
 
 -- | Stores state on the React component instance - i.e. `this.setState`. See
 -- | comment on `StateStrategy`.
 localState :: forall state. StateStrategy state
-localState {initialState} = {
+localState {initialState} =
+  { initialize: \component ->
+      React.assignState component initialState
 
-    getState: \component -> do
-        mState <- toMaybe <$> React.getState component
-        pure $ fromMaybe initialState mState,
+  , getState: \component -> do
+      mState <- toMaybe <$> React.getState component
+      pure $ fromMaybe initialState mState
 
-    setState: React.setState
-}
+  , setState: React.setState
+  }

--- a/src/Elmish/State.purs
+++ b/src/Elmish/State.purs
@@ -56,7 +56,7 @@ dedicatedStorage = mkStrategy <$> Ref.new Nothing
     where
     mkStrategy :: Ref (Maybe state) -> StateStrategy state
     mkStrategy stateVar {initialState} =
-      { initialize: \_ -> pure unit
+      { initialize: \_ -> Ref.write (Just initialState) stateVar
 
       , getState: \_ -> fromMaybe initialState <$> Ref.read stateVar
 

--- a/test/Component.purs
+++ b/test/Component.purs
@@ -2,16 +2,15 @@ module Test.Component (spec) where
 
 import Prelude
 
-import Elmish (ComponentDef)
 import Elmish.Enzyme (clickOn, find, testComponent, text, (>>))
-import Elmish.HTML.Styled as H
+import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
 spec :: Spec Unit
 spec = describe "Elmish.Component" do
   it "can mount and drive a basic component" do
-    testComponent def do
+    testComponent (Counter.def { initialCount: 0 }) do
       find "p" >> text >>= shouldEqual "The count is: 0"
       clickOn "button.t--inc"
       find "p" >> text >>= shouldEqual "The count is: 1"
@@ -19,21 +18,3 @@ spec = describe "Elmish.Component" do
       find "p" >> text >>= shouldEqual "The count is: 2"
       clickOn "button.t--dec"
       find "p" >> text >>= shouldEqual "The count is: 1"
-
-type State = { count :: Int }
-data Message = Inc | Dec
-
-def :: ComponentDef Message State
-def = { init, view, update }
-  where
-    init = pure { count: 0 }
-
-    view state dispatch =
-      H.div ""
-      [ H.p "" $ "The count is: " <> show state.count
-      , H.button_ "t--inc" { onClick: dispatch Inc } "Inc"
-      , H.button_ "t--dec" { onClick: dispatch Dec } "Dec"
-      ]
-
-    update s Inc = pure s { count = s.count + 1 }
-    update s Dec = pure s { count = s.count - 1 }

--- a/test/Examples/Counter.purs
+++ b/test/Examples/Counter.purs
@@ -1,0 +1,34 @@
+module Test.Examples.Counter
+  ( State
+  , Message(..)
+  , def
+  , init
+  , view
+  , update
+  ) where
+
+import Prelude
+
+import Elmish (ComponentDef, Dispatch, ReactElement, Transition)
+import Elmish.HTML.Styled as H
+
+type State = { count :: Int }
+data Message = Inc | Dec
+
+def :: { initialCount :: Int } -> ComponentDef Message State
+def args = { init: init args, view, update }
+
+init :: { initialCount :: Int } -> Transition Message State
+init { initialCount } = pure { count: initialCount }
+
+view :: State -> Dispatch Message -> ReactElement
+view state dispatch =
+  H.div ""
+  [ H.p "" $ "The count is: " <> show state.count
+  , H.button_ "t--inc" { onClick: dispatch Inc } "Inc"
+  , H.button_ "t--dec" { onClick: dispatch Dec } "Dec"
+  ]
+
+update :: State -> Message -> Transition Message State
+update s Inc = pure s { count = s.count + 1 }
+update s Dec = pure s { count = s.count - 1 }

--- a/test/LocalState.purs
+++ b/test/LocalState.purs
@@ -34,7 +34,7 @@ spec = describe "Elmish.Component.wrapWithLocalState" do
       find ".t--wrapper-2 p" >> text >>= shouldEqual "The count is: 42"
       exists ".t--wrapper-1 p" >>= shouldEqual false
 
-  it "does not reset local state when initial state changes" do
+  it "does not reset local state when props/args change" do
     testComponent wrapperDef do
       find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 42"
       clickOn "button.t--inc-initial-count"

--- a/test/LocalState.purs
+++ b/test/LocalState.purs
@@ -1,0 +1,80 @@
+module Test.LocalState (spec) where
+
+import Prelude
+
+import Elmish.Component (ComponentName(..), wrapWithLocalState)
+import Elmish.Enzyme (clickOn, exists, find, testComponent, text, (>>))
+import Elmish.HTML.Styled as H
+import Test.Examples.Counter as Counter
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "Elmish.Component.wrapWithLocalState" do
+
+  it "maintains local event loop" do
+    testComponent wrapperDef do
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 42"
+      clickOn "button.t--inc"
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 43"
+      exists ".t--wrapper-2 p" >>= shouldEqual false
+
+  it "resets local state when the component is moved" do
+    testComponent wrapperDef do
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 42"
+      exists ".t--wrapper-2 p" >>= shouldEqual false
+      clickOn "button.t--inc"
+      clickOn "button.t--inc"
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 44"
+
+      clickOn "button.t--toggle-both"
+
+      -- wrapper-2 contains a whole new Counter (as far as React is concerned),
+      -- unrelated to the one in wrapper-1, so it gets a brand new state of 42.
+      find ".t--wrapper-2 p" >> text >>= shouldEqual "The count is: 42"
+      exists ".t--wrapper-1 p" >>= shouldEqual false
+
+  it "does not reset local state when initial state changes" do
+    testComponent wrapperDef do
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 42"
+      clickOn "button.t--inc-initial-count"
+
+      -- The counter in wrapper-1 was already initialized by the time
+      -- initialCount got incremented, so the new value of initialCount
+      -- shouldn't affect wrapper-1's state.
+      find ".t--wrapper-1 p" >> text >>= shouldEqual "The count is: 42"
+
+      clickOn "button.t--toggle-second"
+
+      -- But the counter in wrapper-2 gets initialized _after_ initialCount
+      -- became 43, so that's what wrapper-2's state should become.
+      find ".t--wrapper-2 p" >> text >>= shouldEqual "The count is: 43"
+
+  where
+    wrappedCounter =
+      wrapWithLocalState (ComponentName "Counter") \c ->
+        Counter.def { initialCount: c }
+
+    wrapperDef = { init, view, update }
+      where
+        init = pure { initialCount: 42, showFirst: true, showSecond: false }
+
+        view state dispatch =
+          H.fragment
+          [ H.div "t--wrapper-1" $
+              if state.showFirst then wrappedCounter state.initialCount else H.empty
+          , H.div "t--wrapper-2" $
+              if state.showSecond then wrappedCounter state.initialCount else H.empty
+          , H.button_ "t--toggle-first" { onClick: dispatch "ToggleFirst" } "."
+          , H.button_ "t--toggle-second" { onClick: dispatch "ToggleSecond" } "."
+          , H.button_ "t--toggle-both" { onClick: dispatch "ToggleBoth" } "."
+          , H.button_ "t--inc-initial-count" { onClick: dispatch "IncInitialCount" } "."
+          ]
+
+        update state = case _ of
+          "ToggleFirst" -> pure state { showFirst = not state.showFirst }
+          "ToggleSecond" -> pure state { showSecond = not state.showSecond }
+          "ToggleBoth" -> pure state { showFirst = not state.showFirst, showSecond = not state.showSecond }
+          "IncInitialCount" -> pure state { initialCount = state.initialCount + 1 }
+          _ -> pure state
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,6 +8,7 @@ import Elmish.Enzyme as Enzyme
 import Elmish.Enzyme.Adapter as Adapter
 import Test.Component as Component
 import Test.Foreign as Foreign
+import Test.LocalState as LocalState
 import Test.Spec.Reporter (specReporter)
 import Test.Spec.Runner (runSpec)
 
@@ -19,3 +20,4 @@ main = do
   launchAff_ $ runSpec [specReporter] do
     Foreign.spec
     Component.spec
+    LocalState.spec


### PR DESCRIPTION
Now that we have Enzyme-powered tests, I can finally write a test for this bug to make sure I got the repro right, and then fix the bug and verify by observing that the test passes.

The bug is related to the initial state: a component created via `wrapWithLocalState` keeps its state using React's own mechanism (i.e. `this.state` / `this.setState`), but it never gives React the _initial_ state, leaving it `undefined`. Instead, it was just coercing `undefined` to `initialState` at time of reading, roughly equivalent to this:

```
let getState = () => this.state ?? calculateInitialState(this.props)
```

This means that _until the first call to `this.setState`_, the component's state is effectively equivalent to whatever is passed in props. Which means that the component's state gets effectively "reset" every time its props change. 

This is counterintuitive even on its own (i.e. a component's state should stay put once the component is mounted), but even more importantly, this is inconsistent: before the first `setState` call the state is derived from props, but after the first `setState` call the state is its own thing.

[This test](https://github.com/collegevine/purescript-elmish/pull/50/files#diff-7ab063bf67c2d1dceb52a89c19e908f78a27bb8b9bc4d2141c48ab49c1758f5cR37-R51) catches the bug.

To fix the bug, this PR effectively adds the mandatory `this.state = calculateInitialState(props)` _to the component's constructor_, as the React gods intended. This way the state is never `undefined`, so it always stays put until the component is unmounted.