### PR TITLE
Give generated React components proper names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{js,json,yml,yaml}]
+[*.{js,json,yml,yaml,dhall}]
 indent_size = 2
 
 [*.purs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - React props for FFI-imported components are now allowed to have a `ref` prop.
   This was a silly restriction.
+- Generated React component classes now have more descriptive names. This is to
+  help with debugging and testing. See
+  [#52](https://github.com/collegevine/purescript-elmish/pull/52).
 
 ## 0.5.7
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       "dev": true
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
     },
     "array.prototype.filter": {
@@ -863,6 +863,28 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -1374,6 +1396,23 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "execa": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^3.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1534,6 +1573,15 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      }
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
       }
     },
     "get-symbol-description": {
@@ -1929,6 +1977,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -1949,6 +2003,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-string": {
@@ -2287,9 +2347,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -2495,6 +2555,15 @@
         "optimist": ">=0.3.4"
       }
     },
+    "npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
     "nth-check": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
@@ -2599,12 +2668,12 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optimist": {
@@ -2649,6 +2718,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
       "dev": true
     },
     "pako": {
@@ -2715,6 +2790,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -2884,153 +2965,40 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.4.tgz",
-      "integrity": "sha512-9Lq2qvyVkQoKUBSNOEBKIJjtD5sDwThurSt3SRdtSseaA03p1Fk7VxbUr9HV/gHLVZPIkOhPtjvZGUNs5U2PDA==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.5.tgz",
+      "integrity": "sha512-bJriK+8MssEsk++itpHL1FgqbgqxoWPgyLIkoC54k7g2Wfsj8M1svQcXcRSu1UZRixu+pg7COQF7uDref/nO2Q==",
       "dev": true,
       "requires": {
         "purescript-installer": "^0.2.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "which": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
-        "execa": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^3.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "purescript-installer": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/purescript-installer/-/purescript-installer-0.2.5.tgz",
-          "integrity": "sha512-fQAWWP5a7scuchXecjpU4r4KEgSPuS6bBnaP01k9f71qqD28HaJ2m4PXHFkhkR4oATAxTPIGCtmTwtVoiBOHog==",
-          "dev": true,
-          "requires": {
-            "arch": "^2.1.1",
-            "byline": "^5.0.0",
-            "cacache": "^11.3.2",
-            "chalk": "^2.4.2",
-            "env-paths": "^2.2.0",
-            "execa": "^2.0.3",
-            "filesize": "^4.1.2",
-            "is-plain-obj": "^2.0.0",
-            "log-symbols": "^3.0.0",
-            "log-update": "^3.2.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "ms": "^2.1.2",
-            "once": "^1.4.0",
-            "pump": "^3.0.0",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "tar": "^4.4.6",
-            "which": "^1.3.1",
-            "zen-observable": "^0.8.14"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        }
+      }
+    },
+    "purescript-installer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/purescript-installer/-/purescript-installer-0.2.5.tgz",
+      "integrity": "sha512-fQAWWP5a7scuchXecjpU4r4KEgSPuS6bBnaP01k9f71qqD28HaJ2m4PXHFkhkR4oATAxTPIGCtmTwtVoiBOHog==",
+      "dev": true,
+      "requires": {
+        "arch": "^2.1.1",
+        "byline": "^5.0.0",
+        "cacache": "^11.3.2",
+        "chalk": "^2.4.2",
+        "env-paths": "^2.2.0",
+        "execa": "^2.0.3",
+        "filesize": "^4.1.2",
+        "is-plain-obj": "^2.0.0",
+        "log-symbols": "^3.0.0",
+        "log-update": "^3.2.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "ms": "^2.1.2",
+        "once": "^1.4.0",
+        "pump": "^3.0.0",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "tar": "^4.4.6",
+        "which": "^1.3.1",
+        "zen-observable": "^0.8.14"
       }
     },
     "purescript-psa": {
@@ -3244,6 +3212,23 @@
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        }
       }
     },
     "ret": {
@@ -3368,6 +3353,21 @@
         "fast-safe-stringify": "^2.0.7"
       }
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
@@ -3386,9 +3386,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
     "simple-concat": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jsdom": "^19.0.0",
     "lodash": "^4.17.21",
     "pulp": "^15.0.0",
-    "purescript": "^0.14.4",
+    "purescript": "^0.14.5",
     "purescript-psa": "0.7.3",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,6 +2,11 @@ let upstream =
       https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.5-20220102/src/packages.dhall sha256:17ca27f650e91813019dd8c21595b3057d6f4986118d22205bdc7d6ed1ca28e8
 
 in  upstream
+  -- `elmish-enzyme` and `elmish-html` are used in integration tests. Because
+  -- they both depend on Elmish, we have to remove Elmish from their
+  -- dependencies, otherwise Spago will install another copy of Elmish from the
+  -- package set, and we'll end up with two copies of Elmish, leading to module
+  -- name conflicts during compilation.
   with elmish-enzyme.dependencies = [ "prelude" ]
   with elmish-enzyme.version = "v0.0.2"
   with elmish-html.dependencies = [ "prelude", "record" ]

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,16 +1,7 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.4/src/packages.dhall sha256:eee0765aa98e0da8fc414768870ad588e7cada060f9f7c23c37385c169f74d9f
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.5-20220102/src/packages.dhall sha256:17ca27f650e91813019dd8c21595b3057d6f4986118d22205bdc7d6ed1ca28e8
 
 in  upstream
-
-      -- `elmish-enzyme` and `elmish-html` are used in integration tests.
-      -- Because they both depend on Elmish, we have to remove Elmish from their
-      -- dependencies, otherwise Spago will install another copy of Elmish from
-      -- the package set, and we'll end up with two copies of Elmish, leading to
-      -- module name conflicts during compilation.
-      with elmish-enzyme = {
-            dependencies = ["prelude"],
-            repo = "https://github.com/collegevine/purescript-elmish-enzyme.git",
-            version = "v0.0.2"
-      }
-      with elmish-html.dependencies = ["prelude", "record"]
+  with elmish-enzyme.dependencies = [ "prelude" ]
+  with elmish-enzyme.version = "v0.0.2"
+  with elmish-html.dependencies = [ "prelude", "record" ]

--- a/src/Elmish/Component.js
+++ b/src/Elmish/Component.js
@@ -4,7 +4,7 @@ exports.withCachedComponent = (function() {
   const cache = {}
 
   return function(name, f) {
-    const c = cache[name] || (cache[name] = mkFreshComponent())
+    const c = cache[name] || (cache[name] = mkFreshComponent(name))
     return f(c)
   }
 })()
@@ -15,7 +15,7 @@ exports.withFreshComponent = function(f) {
 
 exports.instantiateBaseComponent = React.createElement
 
-function mkFreshComponent() {
+function mkFreshComponent(name) {
   class ElmishComponent extends React.Component {
     constructor(props) {
       super(props)
@@ -31,5 +31,6 @@ function mkFreshComponent() {
     }
   }
 
+  ElmishComponent.displayName = name ? ("Elmish:" + name) : "ElmishRoot"
   return ElmishComponent
 }

--- a/src/Elmish/Component.js
+++ b/src/Elmish/Component.js
@@ -31,6 +31,6 @@ function mkFreshComponent(name) {
     }
   }
 
-  ElmishComponent.displayName = name ? ("Elmish:" + name) : "ElmishRoot"
+  ElmishComponent.displayName = name ? ("Elmish_" + name) : "ElmishRoot"
   return ElmishComponent
 }

--- a/test/Component.purs
+++ b/test/Component.purs
@@ -2,7 +2,7 @@ module Test.Component (spec) where
 
 import Prelude
 
-import Elmish.Enzyme (clickOn, find, testComponent, text, (>>))
+import Elmish.Enzyme (clickOn, find, name, parent, testComponent, text, (>>))
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -18,3 +18,7 @@ spec = describe "Elmish.Component" do
       find "p" >> text >>= shouldEqual "The count is: 2"
       clickOn "button.t--dec"
       find "p" >> text >>= shouldEqual "The count is: 1"
+
+  it "names the root component ElmishRoot" $
+    testComponent (Counter.def { initialCount: 0 }) $
+      find "div" >> parent >> name >>= shouldEqual "ElmishRoot"

--- a/test/LocalState.purs
+++ b/test/LocalState.purs
@@ -3,7 +3,7 @@ module Test.LocalState (spec) where
 import Prelude
 
 import Elmish.Component (ComponentName(..), wrapWithLocalState)
-import Elmish.Enzyme (clickOn, exists, find, name, parent, testComponent, text, (>>))
+import Elmish.Enzyme (clickOn, exists, find, findAll, length, name, parent, testComponent, text, (>>))
 import Elmish.HTML.Styled as H
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
@@ -51,8 +51,11 @@ spec = describe "Elmish.Component.wrapWithLocalState" do
       find ".t--wrapper-2 p" >> text >>= shouldEqual "The count is: 43"
 
   it "names the React component according to the ComponentName passed in" $
-    testComponent wrapperDef $
-      find ".t--wrapper-1 div" >> parent >> name >>= shouldEqual "Elmish:Counter"
+    testComponent wrapperDef do
+      find ".t--wrapper-1 div" >> parent >> name >>= shouldEqual "Elmish_Counter"
+      findAll "Elmish_Counter" >> length >>= shouldEqual 1
+      clickOn ".t--toggle-second"
+      findAll "Elmish_Counter" >> length >>= shouldEqual 2
 
   where
     wrappedCounter =

--- a/test/LocalState.purs
+++ b/test/LocalState.purs
@@ -3,7 +3,7 @@ module Test.LocalState (spec) where
 import Prelude
 
 import Elmish.Component (ComponentName(..), wrapWithLocalState)
-import Elmish.Enzyme (clickOn, exists, find, testComponent, text, (>>))
+import Elmish.Enzyme (clickOn, exists, find, name, parent, testComponent, text, (>>))
 import Elmish.HTML.Styled as H
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
@@ -49,6 +49,10 @@ spec = describe "Elmish.Component.wrapWithLocalState" do
       -- But the counter in wrapper-2 gets initialized _after_ initialCount
       -- became 43, so that's what wrapper-2's state should become.
       find ".t--wrapper-2 p" >> text >>= shouldEqual "The count is: 43"
+
+  it "names the React component according to the ComponentName passed in" $
+    testComponent wrapperDef $
+      find ".t--wrapper-1 div" >> parent >> name >>= shouldEqual "Elmish:Counter"
 
   where
     wrappedCounter =


### PR DESCRIPTION
For debugging and testing purposes, it would be useful if different Elmish-generated components weren't all named "ElmishComponent". This was ok before, when we mostly just had one component per app, but now that we're using more and more self-contained event loops, this may become somewhat confusing.

* The "root" components (i.e. ones created via `construct`) are all named `ElmishRoot`.
* The components created via `wrapWithLocalState` are named `Elmish_<name>`, where `<name>` is the `ComponentName` passed to `wrapWithLocalState`.
    * At first I considered a colon `Elmish:<name>` instead of underscore `Elmish_<name>`, but colon wouldn't work for selecting such components in Enzyme, e.g. `find "Elmish:Foobar"` - the "Foobar" part here would be interpreted as a CSS assertion rather than part of the element name.
* These names show up in React tools for Chrome/Edge as well as in Enzyme tests.

![image](https://user-images.githubusercontent.com/4219105/147959235-c4eadcd9-79aa-4b35-b0aa-f2cba584645a.png)
