### PR TITLE
Make import of ReactDOMServer work with React 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        react-version: [16, 17, 18]
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -19,11 +23,11 @@ jobs:
           .spago
           output
           node_modules
-        key: build-atrifacts-v1-${{ hashFiles('package-lock.json', 'spago.dhall', 'packages.dhall') }}
+        key: build-atrifacts-v1-${{ matrix.react-version }}-${{ hashFiles('package-lock.json', 'spago.dhall', 'packages.dhall') }}
     - uses: actions/setup-node@v2
       with:
         node-version: 14.19.1
-    - run: npm i
+    - run: npm i --save react@${{ matrix.react-version }} && npm i
     - run: npm run build
     - run: npm run test
 

--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import ReactDOMServer from "react-dom/server.js";
+import ReactDOMServer from "react-dom/server";
 
 export function getState_(component) {
   return component.state && component.state.s;


### PR DESCRIPTION
Importing `react-dom/server.js` works with React 16 and 17, but for some reason fails with React 18. `esbuild` reports that "reac-dom does not export server.js".

