### PR TITLE
Lowest precedence for <| and <?|

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           .spago
           output
           node_modules
-        key: build-atrifacts-v2-${{ hashFiles('package-lock.json', 'spago.dhall', 'packages.dhall') }}
+        key: build-artifacts-v2-${{ hashFiles('package-lock.json', 'spago.dhall', 'packages.dhall') }}
     - uses: actions/setup-node@v2
       with:
         node-version: 14.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2
+
+### Changed
+
+- Operators `<|` and `<?|` now have zero precedence, allowing mixing them with
+  the `$` operator, e.g. `dispatch <| foo $ bar $ baz`
+
 ## 0.9.0
 
 ### Added

--- a/src/Elmish/Dispatch.purs
+++ b/src/Elmish/Dispatch.purs
@@ -20,8 +20,8 @@ import Effect.Uncurried as E
 -- | A function that a view can use to report messages originating from JS/DOM.
 type Dispatch msg = msg -> Effect Unit
 
-infixr 9 handle as <|
-infixr 9 handleMaybe as <?|
+infixr 0 handle as <|
+infixr 0 handleMaybe as <?|
 
 class Handle msg event f | f -> msg event where
     -- | A convenience function to make construction of event handlers with


### PR DESCRIPTION
By suggestion from @mcordova47, making precedence of `<|` and `<?|` zero, so that they can be used like `dispatch <| foo $ stuff $ more $ stuff`. 

This works, even though `$` also has zero precedence, because `<|` and `<?|` are left-associative, while `$` is right-associative, so mixing them in the same expression is allowed.