### PR TITLE
Force Maybe in handleMaybe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3
+
+### Changed
+
+- `handleMaybe` now forces `Maybe`, allowing use of ambiguous functors, e.g.
+  `onClick: dispatch <?| pure Foo`
+
 ## 0.9.2
 
 ### Changed

--- a/spago.dhall
+++ b/spago.dhall
@@ -19,6 +19,8 @@
   , "partial"
   , "prelude"
   , "refs"
+  , "safe-coerce"
+  , "type-equality"
   , "typelevel-prelude"
   , "undefined-is-not-a-problem"
   , "unsafe-coerce"


### PR DESCRIPTION
Before this change, the following doesn't compile:

```haskell
onKeyUp: dispatch <?| \(E.KeyboardEvent e) -> guard (e.keyCode == 27) $> Cancel
```

This happens because both `guard` and `$>` work for any functor, so the compiler doesn't know that it's supposed to be `Maybe`, and because it doesn't know, it cannot match the `event -> Maybe msg` instance. The instance can either match or not match depending on whether the unknown functor is `Maybe` or something else. This means that the compiler cannot pick the instance until it knows the functor.

The change in this PR makes the instance match _any_ functor, but after the match is done, it forces the functor to be `Maybe` via a `TypeEquals` constraint. This allows the snippet above to compile.