### PR TITLE
Subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0
+
+### Added
+
+- support for subscriptions - see the `Elmish.Subscriptions` module.
+
+### Changed
+
+- **Breaking**: `forks`'s parameter now takes a record of `{ dispatch, onStop }`
+  instead of just a naked `dispatch` function. This change is in support of
+  subscriptions.
+
 ## 0.10.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- support for subscriptions - see the `Elmish.Subscriptions` module.
+- support for subscriptions - see the `Elmish.Subscription` module.
 
 ### Changed
 

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -3,11 +3,11 @@ module Elmish
     , module Elmish.Component
     , module Elmish.Dispatch
     , module Elmish.React
-    , module Elmish.Subscriptions
+    , module Elmish.Subscription
     ) where
 
 import Elmish.Boot (BootRecord, boot)
 import Elmish.Component (ComponentDef, ComponentDef', Transition, Transition'(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
 import Elmish.Dispatch (Dispatch, handle, handleMaybe, (<|), (<?|))
 import Elmish.React (ReactComponent, ReactElement, Ref, callbackRef, createElement, createElement')
-import Elmish.Subscriptions (subscribe, subscribeMaybe)
+import Elmish.Subscription (subscribe, subscribeMaybe)

--- a/src/Elmish.purs
+++ b/src/Elmish.purs
@@ -3,9 +3,11 @@ module Elmish
     , module Elmish.Component
     , module Elmish.Dispatch
     , module Elmish.React
+    , module Elmish.Subscriptions
     ) where
 
 import Elmish.Boot (BootRecord, boot)
 import Elmish.Component (ComponentDef, ComponentDef', Transition, Transition'(..), bimap, construct, fork, forks, forkVoid, forkMaybe, lmap, nat, rmap, transition, withTrace)
 import Elmish.Dispatch (Dispatch, handle, handleMaybe, (<|), (<?|))
 import Elmish.React (ReactComponent, ReactElement, Ref, callbackRef, createElement, createElement')
+import Elmish.Subscriptions (subscribe, subscribeMaybe)

--- a/src/Elmish/Component.js
+++ b/src/Elmish/Component.js
@@ -29,6 +29,10 @@ function mkFreshComponent(name) {
     componentDidMount() {
       this.props.componentDidMount(this)()
     }
+
+    componentWillUnmount() {
+      this.props.componentWillUnmount(this)()
+    }
   }
 
   ElmishComponent.displayName = name ? ("Elmish_" + name) : "ElmishRoot"

--- a/src/Elmish/Component.purs
+++ b/src/Elmish/Component.purs
@@ -152,7 +152,7 @@ fork cmd = transition unit [cmd]
 -- | component is unmounted.
 -- |
 -- | NOTE: the `onStop` callback is not recommended for direct use, use the
--- | subscriptions API in `Elmish.Subscriptions` instead.
+-- | subscriptions API in `Elmish.Subscription` instead.
 -- |
 -- | Example:
 -- |

--- a/src/Elmish/React.js
+++ b/src/Elmish/React.js
@@ -65,3 +65,6 @@ function flattenDataProp(component, props) {
   }
   return Object.assign({}, props, data)
 }
+
+export const getField_ = (field, obj) => obj[field]
+export const setField_ = (field, value, obj) => obj[field] = value

--- a/src/Elmish/Subscription.purs
+++ b/src/Elmish/Subscription.purs
@@ -45,7 +45,7 @@
 -- |          view = ...
 -- |          update = ...
 -- |
-module Elmish.Subscriptions
+module Elmish.Subscription
   ( Subscription(..)
   , subscribe
   , subscribeMaybe

--- a/src/Elmish/Subscription.purs
+++ b/src/Elmish/Subscription.purs
@@ -45,7 +45,7 @@
 -- |          view = ...
 -- |          update = ...
 -- |
-module Elmish.Subscription
+module Elmish.Subscriptions
   ( Subscription(..)
   , subscribe
   , subscribeMaybe

--- a/src/Elmish/Subscription.purs
+++ b/src/Elmish/Subscription.purs
@@ -1,0 +1,119 @@
+-- | A facade API for expressing the idea of "external events" - i.e. messages
+-- | that do not originate in the UI itself, but come from other sources, such
+-- | as network, browser URL history manipulations, timer, JS workers, and so
+-- | on. The API in this module allows capturing such external events and
+-- | convert them to Elmish messages, so they can be handled in the UI
+-- | component's `update` function.
+-- |
+-- | A `Subscription` value represents such an "external event" packaged for
+-- | reuse, while `subscribe` and `subscribeMaybe` functions allow to "start"
+-- | such subscription by including it in a state transition - usually the
+-- | initial one. When the component is destroyed (in React lingo -
+-- | "unmounted"), all its subscriptions are terminated.
+-- |
+-- | Example:
+-- |
+-- |      -- A reusable library
+-- |      module Location where
+-- |
+-- |      urlUpdates :: ∀ m. MonadEffect m => Subscription m { path :: String, query :: String }
+-- |      urlUpdates = Subscription \dispatch -> do
+-- |        listener <- eventListener \_ -> do
+-- |          path <- window >>= location >>= pathname
+-- |          query <- window >>= location >>= search
+-- |          dispatch { path, query }
+-- |
+-- |        window <#> toEventTarget >>= addEventListener popstate listener false
+-- |
+-- |        pure $
+-- |          window <#> toEventTarget >>= removeEventListener popstate listener false
+-- |
+-- |
+-- |      -- Consuming code
+-- |      type State = ...
+-- |      data Message
+-- |        = UrlChanged { path :: String, query :: String }
+-- |        | ...
+-- |
+-- |      myComponent :: ComponentDef Message State
+-- |      myComponent = { init, view, update }
+-- |        where
+-- |          init = do
+-- |            subscribe UrlChanged Location.urlUpdates
+-- |            ...
+-- |
+-- |          view = ...
+-- |          update = ...
+-- |
+module Elmish.Subscription
+  ( Subscription
+  , subscribe
+  , subscribeMaybe
+  )
+  where
+
+import Prelude
+
+import Data.Maybe (Maybe(..), maybe)
+import Effect.Class (class MonadEffect, liftEffect)
+import Elmish.Component (Transition', forks)
+import Elmish.Dispatch (Dispatch)
+
+-- | Represents an external event, such as network, times, JS worker, etc.
+-- |
+-- | The value wrapped in the newtype is a function that takes a
+-- | message-dispatching callback, through which the subscription can send
+-- | messages, and returns a "cleanup" action, which will be executed when it's
+-- | time to unsubscribe from the subscription.
+newtype Subscription m a = Subscription (Dispatch a -> m (m Unit))
+derive instance Functor (Subscription m)
+
+-- | Given a subscription and a message constructor, this function "starts" the
+-- | subscription by embedding it in a state transition, which is then intended
+-- | to be part of a larger state transition - either a component's `update` or
+-- | `init` function.
+-- |
+-- | Example:
+-- |
+-- |      data Message
+-- |        = UrlChanged { path :: String, query :: String }
+-- |        | ...
+-- |
+-- |      myComponent :: ComponentDef Message State
+-- |      myComponent = { init, view, update }
+-- |        where
+-- |          init = do
+-- |            subscribe UrlChanged Location.urlUpdates
+-- |            ...
+-- |
+-- |          view = ...
+-- |          update = ...
+-- |
+subscribe :: ∀ m a msg. MonadEffect m => (a -> msg) -> Subscription m a -> Transition' m msg Unit
+subscribe f = subscribeMaybe (Just <<< f)
+
+-- | Similar to `subscribe`, but instead of a message constructor, takes a
+-- | function returning `Maybe Message` for issuing messages conditionally.
+-- |
+-- | Example:
+-- |
+-- |      data Message
+-- |        = UrlChanged String
+-- |        | ...
+-- |
+-- |      myComponent :: ComponentDef Message State
+-- |      myComponent = { init, view, update }
+-- |        where
+-- |          init = do
+-- |            Location.urlUpdates # subscribeMaybe \{ path } ->
+-- |              if path == "boring" then Nothing else Just $ UrlChanged path
+-- |            ...
+-- |
+-- |          view = ...
+-- |          update = ...
+-- |
+subscribeMaybe :: ∀ m a msg. MonadEffect m => (a -> Maybe msg) -> Subscription m a -> Transition' m msg Unit
+subscribeMaybe f (Subscription go) =
+  forks \{ dispatch, onStop } -> do
+    stop <- go $ f >>> maybe (pure unit) dispatch
+    liftEffect $ onStop stop

--- a/src/Elmish/Subscription.purs
+++ b/src/Elmish/Subscription.purs
@@ -2,7 +2,7 @@
 -- | that do not originate in the UI itself, but come from other sources, such
 -- | as network, browser URL history manipulations, timer, JS workers, and so
 -- | on. The API in this module allows capturing such external events and
--- | convert them to Elmish messages, so they can be handled in the UI
+-- | converting them to Elmish messages, so they can be handled in the UI
 -- | component's `update` function.
 -- |
 -- | A `Subscription` value represents such an "external event" packaged for

--- a/src/Elmish/Subscription.purs
+++ b/src/Elmish/Subscription.purs
@@ -46,7 +46,7 @@
 -- |          update = ...
 -- |
 module Elmish.Subscription
-  ( Subscription
+  ( Subscription(..)
   , subscribe
   , subscribeMaybe
   )

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [ "avar", "now", "spec", "elmish-testing-library", "elmish-html" ]
+  dependencies = conf.dependencies # [ "avar", "spec", "elmish-testing-library", "elmish-html" ]
 }

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [ "spec", "elmish-testing-library", "elmish-html" ]
+  dependencies = conf.dependencies # [ "avar", "now", "spec", "elmish-testing-library", "elmish-html" ]
 }

--- a/test/Component.purs
+++ b/test/Component.purs
@@ -2,10 +2,17 @@ module Test.Component (spec) where
 
 import Prelude
 
-import Elmish.Test (clickOn, find, nearestEnclosingReactComponentName, testComponent, text, (>>))
+import Effect.Aff.AVar as AVar
+import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (liftEffect)
+import Effect.Ref as Ref
+import Elmish (ComponentDef, forks, (<|))
+import Elmish.Component (ComponentName(..), wrapWithLocalState)
+import Elmish.HTML.Styled as H
+import Elmish.Test (clickOn, find, nearestEnclosingReactComponentName, testComponent, text, waitUntil, (>>))
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
-import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Assertions (fail, shouldEqual)
 
 spec :: Spec Unit
 spec = describe "Elmish.Component" do
@@ -22,3 +29,59 @@ spec = describe "Elmish.Component" do
   it "names the root component ElmishRoot" $
     testComponent (Counter.def { initialCount: 0 }) $
       find "div" >> nearestEnclosingReactComponentName >>= shouldEqual "ElmishRoot"
+
+  it "closes out subscriptions" do
+    c <- subscribedComponent { def: Counter.def { initialCount: 0 }, onTrigger: Counter.Inc }
+
+    testComponent (wrapperComponent c.def) do
+      liftEffect (Ref.read c.alive) >>= shouldEqual false
+      clickOn ".t--show"
+      waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
+      find "p" >> text >>= shouldEqual "The count is: 0"
+      liftAff $ AVar.put unit c.trigger
+      waitUntil $ find "p" >> text <#> eq "The count is: 1"
+      liftEffect (Ref.read c.alive) >>= shouldEqual true
+
+      clickOn ".t--hide"
+      waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
+
+      clickOn ".t--show"
+      waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
+
+      clickOn ".t--hide"
+      waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
+
+subscribedComponent :: ∀ m msg state. MonadAff m
+  => { def :: ComponentDef msg state, onTrigger :: msg }
+  -> m { alive :: Ref.Ref Boolean, trigger :: AVar.AVar Unit, def :: ComponentDef msg state }
+subscribedComponent args = do
+  alive <- liftEffect $ Ref.new false
+  trigger <- liftAff AVar.empty
+
+  let subscription = forks \{ dispatch, onStop } -> do
+        liftEffect $ Ref.write true alive
+        liftEffect $ onStop $ liftEffect $ Ref.write false alive
+        void $ AVar.take trigger
+        liftEffect (Ref.read alive) >>=
+          if _
+            then liftEffect (dispatch args.onTrigger)
+            else fail "Triggered while not alive"
+
+  pure
+    { def: args.def { init = subscription *> args.def.init }
+    , alive
+    , trigger
+    }
+
+wrapperComponent :: ∀ msg state. ComponentDef msg state -> ComponentDef Boolean Boolean
+wrapperComponent inner = { init: pure false, update, view }
+  where
+    update _ s = pure s
+
+    view s dispatch = H.fragment
+      [ H.button_ "t--show" { onClick: dispatch <| true } "Show"
+      , H.button_ "t--hide" { onClick: dispatch <| false } "Hide"
+      , if s
+          then wrapWithLocalState (ComponentName "Inner") (const inner) unit
+          else H.empty
+      ]

--- a/test/Component.purs
+++ b/test/Component.purs
@@ -2,17 +2,10 @@ module Test.Component (spec) where
 
 import Prelude
 
-import Effect.Aff.AVar as AVar
-import Effect.Aff.Class (class MonadAff, liftAff)
-import Effect.Class (liftEffect)
-import Effect.Ref as Ref
-import Elmish (ComponentDef, forks, (<|))
-import Elmish.Component (ComponentName(..), wrapWithLocalState)
-import Elmish.HTML.Styled as H
-import Elmish.Test (clickOn, find, nearestEnclosingReactComponentName, testComponent, text, waitUntil, (>>))
+import Elmish.Test (clickOn, find, nearestEnclosingReactComponentName, testComponent, text, (>>))
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)
-import Test.Spec.Assertions (fail, shouldEqual)
+import Test.Spec.Assertions (shouldEqual)
 
 spec :: Spec Unit
 spec = describe "Elmish.Component" do
@@ -29,59 +22,3 @@ spec = describe "Elmish.Component" do
   it "names the root component ElmishRoot" $
     testComponent (Counter.def { initialCount: 0 }) $
       find "div" >> nearestEnclosingReactComponentName >>= shouldEqual "ElmishRoot"
-
-  it "closes out subscriptions" do
-    c <- subscribedComponent { def: Counter.def { initialCount: 0 }, onTrigger: Counter.Inc }
-
-    testComponent (wrapperComponent c.def) do
-      liftEffect (Ref.read c.alive) >>= shouldEqual false
-      clickOn ".t--show"
-      waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
-      find "p" >> text >>= shouldEqual "The count is: 0"
-      liftAff $ AVar.put unit c.trigger
-      waitUntil $ find "p" >> text <#> eq "The count is: 1"
-      liftEffect (Ref.read c.alive) >>= shouldEqual true
-
-      clickOn ".t--hide"
-      waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
-
-      clickOn ".t--show"
-      waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
-
-      clickOn ".t--hide"
-      waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
-
-subscribedComponent :: ∀ m msg state. MonadAff m
-  => { def :: ComponentDef msg state, onTrigger :: msg }
-  -> m { alive :: Ref.Ref Boolean, trigger :: AVar.AVar Unit, def :: ComponentDef msg state }
-subscribedComponent args = do
-  alive <- liftEffect $ Ref.new false
-  trigger <- liftAff AVar.empty
-
-  let subscription = forks \{ dispatch, onStop } -> do
-        liftEffect $ Ref.write true alive
-        liftEffect $ onStop $ liftEffect $ Ref.write false alive
-        void $ AVar.take trigger
-        liftEffect (Ref.read alive) >>=
-          if _
-            then liftEffect (dispatch args.onTrigger)
-            else fail "Triggered while not alive"
-
-  pure
-    { def: args.def { init = subscription *> args.def.init }
-    , alive
-    , trigger
-    }
-
-wrapperComponent :: ∀ msg state. ComponentDef msg state -> ComponentDef Boolean Boolean
-wrapperComponent inner = { init: pure false, update, view }
-  where
-    update _ s = pure s
-
-    view s dispatch = H.fragment
-      [ H.button_ "t--show" { onClick: dispatch <| true } "Show"
-      , H.button_ "t--hide" { onClick: dispatch <| false } "Hide"
-      , if s
-          then wrapWithLocalState (ComponentName "Inner") (const inner) unit
-          else H.empty
-      ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,9 +9,11 @@ import Test.Foreign as Foreign
 import Test.LocalState as LocalState
 import Test.Spec.Reporter (specReporter)
 import Test.Spec.Runner (runSpec)
+import Test.Subscriptions as Subscriptions
 
 main :: Effect Unit
 main = launchAff_ $ runSpec [specReporter] do
   Foreign.spec
   Component.spec
   LocalState.spec
+  Subscriptions.spec

--- a/test/Subscriptions.purs
+++ b/test/Subscriptions.purs
@@ -1,0 +1,123 @@
+module Test.Subscriptions (spec) where
+
+import Prelude
+
+import Effect.Aff (forkAff)
+import Effect.Aff.AVar as AVar
+import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (liftEffect)
+import Effect.Ref as Ref
+import Elmish (ComponentDef, Transition, forks, (<|))
+import Elmish.Component (ComponentName(..), wrapWithLocalState)
+import Elmish.HTML.Styled as H
+import Elmish.Subscription (Subscription(..), subscribe)
+import Elmish.Test (clickOn, find, testComponent, text, waitUntil, (>>))
+import Test.Examples.Counter as Counter
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (fail, shouldEqual)
+
+spec :: Spec Unit
+spec = describe "Elmish.Component - subscriptions" do
+
+  mkTestCase "directly via forks" subscriptionViaForks
+  mkTestCase "via subscription API" subscriptionViaSubscriptionApi
+
+  where
+    mkTestCase name mkSubscription = describe name do
+      it "single level" do
+        c <- subscribedComponent mkSubscription $ Counter.def { initialCount: 0 }
+
+        testComponent (wrapperComponent "" c.def) do
+          liftEffect (Ref.read c.alive) >>= shouldEqual false
+          clickOn ".t--show-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
+          find "p" >> text >>= shouldEqual "The count is: 0"
+          liftAff $ AVar.put Counter.Inc c.trigger
+          waitUntil $ find "p" >> text <#> eq "The count is: 1"
+          liftEffect (Ref.read c.alive) >>= shouldEqual true
+
+          clickOn ".t--hide-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
+
+          clickOn ".t--show-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
+
+          clickOn ".t--hide-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
+
+      it "doubly nested" do
+        c <- subscribedComponent mkSubscription $ Counter.def { initialCount: 0 }
+        let inner = wrapperComponent "t--inner" c.def
+            outer = wrapperComponent "t--outer" inner
+
+        testComponent outer do
+          liftEffect (Ref.read c.alive) >>= shouldEqual false
+
+          clickOn ".t--outer.t--show-child"
+          liftEffect (Ref.read c.alive) >>= shouldEqual false
+
+          clickOn ".t--inner.t--show-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq true
+
+          -- Telling the 'outer' component to hide the 'inner' component, which
+          -- should also trigger unmounting of the 'c' component inside the
+          -- 'inner', thus ending the subscription.
+          clickOn ".t--outer.t--hide-child"
+          waitUntil $ liftEffect (Ref.read c.alive) <#> eq false
+
+-- A helper component that wraps another component, but adds a subscription,
+-- which (1) sets a boolean cell to true/false on subscribe/unsubscribe and (2)
+-- waits for an AVar to pulse and when it does, issues a given message.
+subscribedComponent :: ∀ m msg state. MonadAff m
+  => ({ alive :: Ref.Ref Boolean, trigger :: AVar.AVar msg } -> Transition msg Unit)
+  -> ComponentDef msg state
+  -> m { alive :: Ref.Ref Boolean, trigger :: AVar.AVar msg, def :: ComponentDef msg state }
+subscribedComponent mkSubscription wrappedDef = do
+  alive <- liftEffect $ Ref.new false
+  trigger <- liftAff AVar.empty
+
+  let subscription = mkSubscription { alive, trigger }
+      def = wrappedDef { init = subscription *> wrappedDef.init }
+
+  pure { def, alive, trigger }
+
+subscriptionViaForks :: ∀ msg. { alive :: Ref.Ref Boolean, trigger :: AVar.AVar msg } -> Transition msg Unit
+subscriptionViaForks { alive, trigger } =
+  forks \{ dispatch, onStop } -> do
+    liftEffect $ Ref.write true alive
+    liftEffect $ onStop $ liftEffect $ Ref.write false alive
+    msg <- AVar.take trigger
+    liftEffect (Ref.read alive) >>=
+      if _
+        then liftEffect (dispatch msg)
+        else fail "Triggered while not alive"
+
+subscriptionViaSubscriptionApi :: ∀ msg. { alive :: Ref.Ref Boolean, trigger :: AVar.AVar msg } -> Transition msg Unit
+subscriptionViaSubscriptionApi { alive, trigger } =
+  subscribe $ Subscription \dispatch -> do
+    liftEffect $ Ref.write true alive
+    void $ forkAff do
+      msg <- AVar.take trigger
+      liftEffect (Ref.read alive) >>=
+        if _
+          then liftEffect (dispatch msg)
+          else fail "Triggered while not alive"
+
+    pure $ liftEffect $ Ref.write false alive
+
+-- Wraps another component, instantiating it via `wrapWithLocalState`, so that
+-- it would mount/unmount when toggled, and displays two buttons for toggling
+-- it. The host test would click the buttons to show/hide the inner component
+-- and verify that it correctly mounted/unmounted.
+wrapperComponent :: ∀ msg state. String -> ComponentDef msg state -> ComponentDef Boolean Boolean
+wrapperComponent className inner = { init: pure false, update, view }
+  where
+    update _ s = pure s
+
+    view s dispatch = H.fragment
+      [ H.button_ (className <> " t--show-child") { onClick: dispatch <| true } "Show"
+      , H.button_ (className <> " t--hide-child") { onClick: dispatch <| false } "Hide"
+      , if s
+          then wrapWithLocalState (ComponentName "Inner") (const inner) unit
+          else H.empty
+      ]

--- a/test/Subscriptions.purs
+++ b/test/Subscriptions.purs
@@ -10,7 +10,7 @@ import Effect.Ref as Ref
 import Elmish (ComponentDef, Transition, forks, (<|))
 import Elmish.Component (ComponentName(..), wrapWithLocalState)
 import Elmish.HTML.Styled as H
-import Elmish.Subscription (Subscription(..), subscribe)
+import Elmish.Subscriptions (Subscription(..), subscribe)
 import Elmish.Test (clickOn, find, testComponent, text, waitUntil, (>>))
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)

--- a/test/Subscriptions.purs
+++ b/test/Subscriptions.purs
@@ -10,7 +10,7 @@ import Effect.Ref as Ref
 import Elmish (ComponentDef, Transition, forks, (<|))
 import Elmish.Component (ComponentName(..), wrapWithLocalState)
 import Elmish.HTML.Styled as H
-import Elmish.Subscriptions (Subscription(..), subscribe)
+import Elmish.Subscription (Subscription(..), subscribe)
 import Elmish.Test (clickOn, find, testComponent, text, waitUntil, (>>))
 import Test.Examples.Counter as Counter
 import Test.Spec (Spec, describe, it)

--- a/test/Subscriptions.purs
+++ b/test/Subscriptions.purs
@@ -94,7 +94,7 @@ subscriptionViaForks { alive, trigger } =
 
 subscriptionViaSubscriptionApi :: ∀ msg. { alive :: Ref.Ref Boolean, trigger :: AVar.AVar msg } -> Transition msg Unit
 subscriptionViaSubscriptionApi { alive, trigger } =
-  subscribe $ Subscription \dispatch -> do
+  subscribe identity $ Subscription \dispatch -> do
     liftEffect $ Ref.write true alive
     void $ forkAff do
       msg <- AVar.take trigger


### PR DESCRIPTION
Introducing Subscriptions!

Though the name is borrowed from Elm, these work a bit differently: rather than having a fourth function `subscriptions` (alongside `init`, `view`, and `update`), adding a subscription is an effect that can be made part of a state transition, including the initial one in `init`.

Under the hood, the material change is that the `forks` function's parameter callback now takes not only `dispatch` to issue messages, but also an `onStop` function that it can use to react to when the component is unmounted, which is essential to implement the concept of "unsubscribing".

The rest is just facade API: the `Subscription` type is crafted in a way to force the author to provide an "unsubscribe" callback, and encodes the type of messages that "come out" of the subscription; the `subscribe` function allows to add such `Subscription` to a state transition and map its output to a consuming component's message.

## Example

```haskell
-- Component consuming the subscription
type State = ...
data Message
  = UrlChanged { path :: String, query :: String }
  | ...

myComponent :: ComponentDef Message State
myComponent = { init, view, update }
  where
    init = do
      subscribe UrlChanged Location.urlUpdates
      ...

    view = ...
    update = ...


-- A reusable library that provides the subscription
module Location where

urlUpdates :: ∀ m. MonadEffect m => Subscription m { path :: String, query :: String }
urlUpdates = Subscription \dispatch -> do
  listener <- eventListener \_ -> do
    path <- window >>= location >>= pathname
    query <- window >>= location >>= search
    dispatch { path, query }

  window <#> toEventTarget >>= addEventListener popstate listener false

  pure $
    window <#> toEventTarget >>= removeEventListener popstate listener false

```