### PR TITLE
Avoid capturing ComponentDef in a closure for a long time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time, which could lead to using stale values in complex scenarios where
   `ComponentDef` is not constant, but depends on arguments. #83
 
-- **Breaking**: Change the order of arguments of `bindComponent`
+- **Breaking**: Changed the order of arguments of `bindComponent`
 
 ## 0.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug that allowed `ComponentDef` to be captured in closures for a long
   time, which could lead to using stale values in complex scenarios where
-  `ComponentDef` is not constant, but depends on arguments. #83
+  `ComponentDef` is not constant, but depends on arguments. See [#83](https://github.com/collegevine/purescript-elmish/pull/83).
 
 - **Breaking**: Changed the order of arguments of `bindComponent`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0
+
+### Changed
+
+- Fixed a bug that allowed `ComponentDef` to be captured in closures for a long
+  time, which could lead to using stale values in complex scenarios where
+  `ComponentDef` is not constant, but depends on arguments. #83
+
+- **Breaking**: Change the order of arguments of `bindComponent`
+
 ## 0.11.4
 
 ### Added

--- a/src/Elmish/Component.js
+++ b/src/Elmish/Component.js
@@ -15,6 +15,8 @@ export function withFreshComponent(f) {
 
 export var instantiateBaseComponent = React.createElement;
 
+export const instancePropDef = component => () => component.props.def
+
 function mkFreshComponent(name) {
   class ElmishComponent extends React.Component {
     constructor(props) {


### PR DESCRIPTION
The `ComponentDef` is captured in closures defined under `where` in `bindComponent`. In most cases this is fine, because `ComponentDef` is constant anyway. And even if not, `bindComponent` is called on every render, which means a new, fresh value of `ComponentDef` is re-captured on every render.

But what if such closure could survive several renders and several changes of `ComponentDef`? If the closure is a `dispatch` function, the next message that is issued through it will call a stale version of `update`. This is particularly important now that we added subscriptions, which keep the initial value of `dispatch` pretty much indefinitely.

See the new test I added in this PR to see how this could happen. If the changes to `bindComponent` are undone, that test fails in exactly the way the comment in it predicts.

To fix this, I am now keeping `ComponentDef` as a prop on the component, and always retrieving it from the component props when needed, rather than capturing it in a closure. This way, whenever the `ComponentDef` is required, it is always the one from the latest render.

There will be another fix in `purescript-hooks` to take advantage of this fix to fix the next level of the same problem.